### PR TITLE
fix: keep footer links on one line

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -18,7 +18,7 @@ export function AppFooter({ importBusy, onUpload }: AppFooterProps) {
         technisch aufbereitet.
       </p>
 
-      <nav className="app-footer-license-links" aria-label="Attribution und Lizenz">
+      <nav className="app-footer-links" aria-label="Attribution, Lizenz und Footer-Navigation">
         <a href={BSI_REPOSITORY_URL} target="_blank" rel="noopener noreferrer">
           BSI-Quelle
         </a>
@@ -26,9 +26,6 @@ export function AppFooter({ importBusy, onUpload }: AppFooterProps) {
           CC BY-SA 4.0
         </a>
         <a href="#/about/license">Quellen &amp; Lizenz</a>
-      </nav>
-
-      <nav className="app-footer-links" aria-label="Footer-Navigation">
         <a href="#/about">About</a>
         <a href="#/impressum">Impressum</a>
         <a href="#/datenschutz">Datenschutz</a>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1584,22 +1584,28 @@ summary:focus-visible,
   line-height: 1.35;
 }
 
-.app-footer-license-links,
 .app-footer-links {
   display: flex;
   gap: 0.3rem 0.9rem;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   font-size: 0.84rem;
   line-height: 1.3;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  scrollbar-width: thin;
 }
 
-.app-footer-license-links a,
 .app-footer-links a {
   color: var(--link);
   text-decoration: underline;
   text-underline-offset: 0.14rem;
   text-decoration-thickness: 0.08rem;
+}
+
+.app-footer-links > * {
+  flex: 0 0 auto;
 }
 
 .app-footer-link-button {
@@ -1843,7 +1849,6 @@ summary:focus-visible,
     font-size: 0.79rem;
   }
 
-  .app-footer-license-links,
   .app-footer-links {
     font-size: 0.81rem;
     gap: 0.22rem 0.72rem;


### PR DESCRIPTION
## Summary
- keep all footer links in a single horizontal row without wrapping
- merge footer link groups into one navigation row
- enforce nowrap styling and horizontal overflow instead of line breaks

## Validation
- npm run test:unit
- npm run build

## Notes
- no data pipeline changes
- no dependency changes