### PR TITLE
fix: remove JSON load functionality and cleanup related artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Kernziele:
 - Detailansicht je Control inkl. Relationen und Graphdarstellung
 - Primärquelle: fertiger BSI-Grundschutz++-Anwenderkatalog
 - CSV-Export ausgewählter Controls
-- lokaler JSON-Import (ohne Server)
 - statisches Deployment (GitHub Pages)
 
 ## Kernfunktionen

--- a/docs/api-and-interfaces.md
+++ b/docs/api-and-interfaces.md
@@ -3,7 +3,7 @@
 ## Überblick
 
 - Es gibt keine serverseitige REST-/GraphQL-API.
-- Externe Schnittstellen sind statische JSON-Dateien, Browser-Routen, Worker-Nachrichten, Datei-Upload und CSV-Download.
+- Externe Schnittstellen sind statische JSON-Dateien, Browser-Routen, Worker-Nachrichten und CSV-Download.
 
 ## 1) Statische Daten-Schnittstellen (`public/data/**`)
 
@@ -47,15 +47,12 @@ Typische Fehler:
 - `get-neighborhood`
   - Payload: `{ id, hops }`
   - Antwort: `RelationGraphPayload`
-- `load-upload`
-  - Payload: `{ rawText }`
-  - Antwort: `{ meta, facetOptions, stats }`
 - `cancel`
   - Payload: vorherige `requestId`
 
 ### Fehlerfälle
 
-- Worker-Timeouts je Operation (10s-45s je Typ)
+- Worker-Timeouts je Operation (10s-30s je Typ)
 - Abgebrochene Requests liefern einen Fehlerpfad
 - Unbekannte Request-Typen werden abgelehnt
 
@@ -80,21 +77,7 @@ Routing-Härtung:
 - Sanitizing für Suchtext/Filter/Routentoken
 - Limits auf Länge und Anzahl
 
-## 4) Upload-Schnittstelle
-
-### Input
-
-- Lokaler Dateiupload (`application/json`)
-- Größenlimit: `8 MiB`
-- Struktur: OSCAL-Katalog (`UploadCatalogSchema`)
-
-### Verhalten
-
-- Validierung und Normalisierung im Worker
-- Bei Erfolg: In-Memory-Ersatz des Suchindex
-- Bei Fehler: keine Teilübernahme
-
-## 5) CSV-Export-Schnittstelle
+## 4) CSV-Export-Schnittstelle
 
 ### Output
 
@@ -114,7 +97,7 @@ Spalten:
 - Spreadsheet-Formel-Präfixe (`=,+,-,@`) werden neutralisiert.
 - Exportiert werden nur `http/https`-Links.
 
-## 6) Security-/Berechtigungsaspekte
+## 5) Security-/Berechtigungsaspekte
 
 - Es gibt keine Authentifizierung/Autorisierung.
 - Fokus liegt auf Eingabehärtung, Budgetgrenzen und sicherer URL-Verarbeitung.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@
 Aufgaben:
 - Routing und Seitenzustände (`src/App.tsx`)
 - Suche, Filter, Detailansichten
-- CSV-Export und lokaler JSON-Upload
+- CSV-Export
 - Quellen-/Lizenz-/Versions- und Rechtsseiten
 
 Wichtige Komponenten:
@@ -27,10 +27,9 @@ Aufgaben:
 - Suchausführung inkl. Ranking, Filterung, Facettenzählung
 - Nachladen von Detail-Chunks
 - Graph-Berechnung (1-/2-Hop)
-- Ingestion von lokal hochgeladenem OSCAL-JSON
 
 Technik:
-- Worker-Protokoll (`init`, `search`, `get-control`, `get-neighborhood`, `load-upload`, `cancel`)
+- Worker-Protokoll (`init`, `search`, `get-control`, `get-neighborhood`, `cancel`)
 - Zod-Schema-Validierung und Budgets
 
 ### Build-/Transformationspipeline (Node)
@@ -52,7 +51,7 @@ Aufgabe:
 ## Hauptmodule
 
 - `src/App.tsx`: Zustands- und Flow-Orchestrierung
-- `src/workers/searchWorker.ts`: Suchkern, Worker-API, Detail-Ladepfad, Upload-Ingestion
+- `src/workers/searchWorker.ts`: Suchkern, Worker-API, Detail-Ladepfad
 - `src/lib/dataSchemas.ts`: zentrale Schema-/Budget-Validierung
 - `src/lib/normalize-core.js`: Extraktion von Gruppen/Controls/Facetten/Relationen aus OSCAL
 - `scripts/build-catalog.mjs`: Datenbuild aus dem Grundschutz++-Anwenderkatalog
@@ -72,12 +71,6 @@ Aufgabe:
 2. Worker lädt bei Bedarf `details/<TOPGROUP>.json`.
 3. UI rendert Treffer, Details, Relationen und Exporte.
 
-### Upload-Zeit (lokal)
-
-1. Nutzer lädt eine JSON-Datei im Browser.
-2. Worker validiert und normalisiert Upload-JSON.
-3. In-Memory-Index ersetzt den statischen Index bis zum Reload.
-
 ## Schnittstellen
 
 - Interne Schnittstellen:
@@ -87,7 +80,6 @@ Aufgabe:
 
 - Externe Schnittstellen:
   - Statische JSON-Dateien unter `./data/**`
-  - Datei-Upload (`application/json`)
   - CSV-Dateidownload als Browser-Blob
 
 ## Zentrale Architekturentscheidungen

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -31,7 +31,7 @@ npm run test:unit
 ## Repository-Struktur verstehen
 
 - `src/App.tsx`: App-Orchestrierung, Routing, Such-/Detail-/Export-Flow
-- `src/workers/searchWorker.ts`: Such-Engine und Daten-Ingestion im Worker
+- `src/workers/searchWorker.ts`: Such-Engine und Worker-API
 - `src/lib/normalize-core.js`: OSCAL -> internes Datenmodell
 - `scripts/build-catalog.mjs`: Build-Datenpipeline
 - `scripts/sync-bsi-catalogs.mjs`: Upstream-Sync des BSI-Grundschutz++-Anwenderkatalogs

--- a/docs/functional-overview.md
+++ b/docs/functional-overview.md
@@ -31,10 +31,9 @@ Die Anwendung stellt Grundschutz++-Katalogdaten als durchsuchbare Oberfläche be
 
 - Anzeige von Version, Build-Informationen und Hash zur aktiven Primärquelle.
 
-### UC-7: Export und lokaler Import
+### UC-7: Export
 
 - CSV-Export ausgewählter Controls.
-- Lokaler JSON-Upload mit Validierung.
 
 ## Fachliche Domänenobjekte
 
@@ -57,5 +56,4 @@ Die Anwendung stellt Grundschutz++-Katalogdaten als durchsuchbare Oberfläche be
 
 - Keine Schreib-/Mutationsoperationen gegen externe Systeme.
 - Kein User-/Rechtemodell.
-- Kein persistenter Upload-Speicher; Upload gilt bis zum Seitenreload.
 - Kein Workflow-Engine-/Freigabeprozess in der Anwendung.

--- a/docs/open-issues-and-gaps.md
+++ b/docs/open-issues-and-gaps.md
@@ -14,7 +14,7 @@
 ## Qualitäts-/Testgaps
 
 1. Es gibt keine Coverage-Metriken.
-2. Es gibt keinen dedizierten Last-/Soak-Test für Worker und große Uploads.
+2. Es gibt keinen dedizierten Last-/Soak-Test für Worker unter hoher Last.
 3. Es gibt keinen dedizierten automationsgestützten Test für reale Response-Header auf dem Produktiv-Host.
 
 ## Betriebsgaps

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -4,9 +4,9 @@
 
 ### Eingabe- und Datenvalidierung
 
-- Zod-Schemas für Index, Meta, Detail-Chunks, Registry, Profilanalyse und Upload-Daten.
+- Zod-Schemas für Index, Meta, Detail-Chunks, Registry und Profilanalyse.
 - Bei Parse-/Schema-/Budgetfehlern wird Verarbeitung abgebrochen.
-- Byte-/Mengen-/Zeitbudgets (`SECURITY_BUDGETS`) für Suche und Upload-Ingestion.
+- Byte-/Mengen-/Zeitbudgets (`SECURITY_BUDGETS`) für Suche und Datenverarbeitung.
 
 ### Such- und Routing-Härtung
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -84,7 +84,7 @@ Workflow `.github/workflows/quality.yml` führt aus:
 
 ### Should-have
 
-1. E2E-Tests für Upload + Graph-Klickpfade erweitern.
+1. E2E-Tests für Graph-Klickpfade erweitern.
 2. Zusätzliche Integrationsprüfungen für Host-spezifisches Laufzeitverhalten ergänzen.
 
 ### Nice-to-have

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,6 @@ import type {
   SearchResponse,
   SearchResultItem
 } from "./types";
-import { validateOrThrow } from "./lib/validation";
 
 const DEFAULT_SEARCH_RESPONSE: SearchResponse = {
   total: 0,
@@ -89,14 +88,6 @@ function toSortValue(base: SortBase, direction: "asc" | "desc"): SearchQuery["so
     return direction === "asc" ? "effort-asc" : "effort-desc";
   }
   return "relevance";
-}
-
-async function computeSha256(text: string) {
-  const encoded = new TextEncoder().encode(text);
-  const digest = await crypto.subtle.digest("SHA-256", encoded);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -206,7 +197,6 @@ export default function App() {
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [toastTone, setToastTone] = useState<"info" | "success" | "error">("info");
-  const [importBusy, setImportBusy] = useState(false);
 
   const debouncedSearchText = useDebouncedValue(searchText, 300);
   const requestCounter = useRef(0);
@@ -668,68 +658,6 @@ export default function App() {
     loadGraph(detail.id, graphHops);
   }, [detail?.id, graphHops]);
 
-  async function handleUpload(file: File) {
-    setImportBusy(true);
-    try {
-      if (file.size > SECURITY_BUDGETS.maxUploadFileSizeBytes) {
-        throw new Error(
-          `Datei zu gross (${file.size} Bytes). Maximal erlaubt: ${SECURITY_BUDGETS.maxUploadFileSizeBytes} Bytes.`
-        );
-      }
-
-      setBootState("loading");
-      setBootError(null);
-      setBootErrorDetails(null);
-      setBootProgress(10);
-      setBootStatusText("Lokale Datei wird gelesen…");
-      const rawText = await file.text();
-      setBootProgress(32);
-      setBootStatusText("Datei wird validiert…");
-      const hash = await computeSha256(rawText);
-      const uploadPayload = await client.loadUpload(rawText);
-      setBootProgress(76);
-      setBootStatusText("Lokaler Datensatz wird integriert…");
-
-      const currentBuildInfo = meta?.buildInfo;
-      const nextMeta = validateOrThrow(
-        {
-          ...(meta as CatalogMeta),
-          ...(uploadPayload.meta as CatalogMeta),
-          buildInfo: {
-            buildTimestamp: new Date().toISOString(),
-            appVersion: currentBuildInfo?.appVersion ?? "0.1.0",
-            indexVersion: currentBuildInfo?.indexVersion ?? "2",
-            catalogFileName: file.name,
-            catalogFileSha256: hash,
-            catalogFileSizeBytes: file.size
-          }
-        },
-        CatalogMetaSchema,
-        "Upload-Metadaten"
-      ) as CatalogMeta;
-
-      setMeta(nextMeta);
-      setBootProgress(100);
-      setBootStatusText("Fertig");
-      setBootState("ready");
-      setGraphData(null);
-      setSelectedControlTopGroups({});
-      setExportCsvMessage(null);
-      setSelectAllRunningScope(null);
-      navigate(buildSearchHash("", "relevance", defaultFilters()));
-      setToastTone("success");
-      setToastMessage("JSON erfolgreich geladen.");
-    } catch (error) {
-      setBootState("error");
-      setBootError(getErrorMessage(error, "Upload konnte nicht verarbeitet werden."));
-      setBootErrorDetails(getErrorDetails(error));
-      setToastTone("error");
-      setToastMessage("JSON-Import fehlgeschlagen.");
-    } finally {
-      setImportBusy(false);
-    }
-  }
-
   function handleToggleControlSelection(item: SearchResultItem, selected: boolean) {
     setSelectedControlTopGroups((prev) => {
       if (selected) {
@@ -1160,7 +1088,7 @@ export default function App() {
             <small>{progress}%</small>
           </div>
         </section>
-        <AppFooter importBusy={importBusy} onUpload={handleUpload} />
+        <AppFooter />
       </main>
     );
   }
@@ -1192,7 +1120,7 @@ export default function App() {
             </button>
           </div>
         </section>
-        <AppFooter importBusy={importBusy} onUpload={handleUpload} />
+        <AppFooter />
       </main>
     );
   }
@@ -1452,7 +1380,7 @@ export default function App() {
         </FilterSheet>
       ) : null}
 
-      <AppFooter importBusy={importBusy} onUpload={handleUpload} />
+      <AppFooter />
     </main>
   );
 }

--- a/src/components/AppDrawer.test.tsx
+++ b/src/components/AppDrawer.test.tsx
@@ -23,6 +23,5 @@ describe("AppDrawer", () => {
     expect(html).not.toContain("Impressum");
     expect(html).not.toContain("Datenschutz");
     expect(html).not.toContain("CSV exportieren");
-    expect(html).not.toContain("JSON laden");
   });
 });

--- a/src/components/AppFooter.test.tsx
+++ b/src/components/AppFooter.test.tsx
@@ -1,10 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { AppFooter } from "./AppFooter";
 
 describe("AppFooter", () => {
-  it("zeigt Links und JSON-Upload-Aktion im Footer", () => {
-    const html = renderToStaticMarkup(<AppFooter importBusy={false} onUpload={vi.fn()} />);
+  it("zeigt Links im Footer", () => {
+    const html = renderToStaticMarkup(<AppFooter />);
 
     expect(html).toContain("Stand-der-Technik-Bibliothek des BSI");
     expect(html).toContain("BSI-Quelle");
@@ -14,11 +14,5 @@ describe("AppFooter", () => {
     expect(html).toContain("About");
     expect(html).toContain("Impressum");
     expect(html).toContain("Datenschutz");
-    expect(html).toContain("JSON laden");
-  });
-
-  it("zeigt Busy-Label waehrend Import", () => {
-    const html = renderToStaticMarkup(<AppFooter importBusy onUpload={vi.fn()} />);
-    expect(html).toContain("JSON wird geladen");
   });
 });

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -1,16 +1,7 @@
-import { useRef } from "react";
-
-interface AppFooterProps {
-  importBusy: boolean;
-  onUpload: (file: File) => void;
-}
-
 const BSI_REPOSITORY_URL = "https://github.com/BSI-Bund/Stand-der-Technik-Bibliothek";
 const CC_BY_SA_4_URL = "https://creativecommons.org/licenses/by-sa/4.0/";
 
-export function AppFooter({ importBusy, onUpload }: AppFooterProps) {
-  const fileRef = useRef<HTMLInputElement | null>(null);
-
+export function AppFooter() {
   return (
     <footer className="app-footer" aria-labelledby="footer-attribution">
       <p id="footer-attribution" className="app-footer-attribution">
@@ -29,29 +20,7 @@ export function AppFooter({ importBusy, onUpload }: AppFooterProps) {
         <a href="#/about">About</a>
         <a href="#/impressum">Impressum</a>
         <a href="#/datenschutz">Datenschutz</a>
-        <button
-          type="button"
-          className="app-footer-link-button"
-          onClick={() => fileRef.current?.click()}
-          disabled={importBusy}
-          title="JSON-Datei laden"
-        >
-          {importBusy ? "JSON wird geladen" : "JSON laden"}
-        </button>
       </nav>
-      <input
-        ref={fileRef}
-        type="file"
-        hidden
-        accept="application/json"
-        onChange={(event) => {
-          const file = event.target.files?.[0];
-          if (file) {
-            onUpload(file);
-          }
-          event.currentTarget.value = "";
-        }}
-      />
     </footer>
   );
 }

--- a/src/components/DatenschutzPage.tsx
+++ b/src/components/DatenschutzPage.tsx
@@ -129,11 +129,10 @@ export function DatenschutzPage() {
         </li>
       </ul>
 
-      <h2>6. Lokale Upload-Verarbeitung (CSV/JSON)</h2>
+      <h2>6. Lokale Verarbeitung (CSV-Export)</h2>
       <p>
-        Wenn Nutzer in der Anwendung CSV- oder JSON-Dateien auswählen/hochladen, werden diese nach aktuellem Stand
-        ausschließlich lokal im Browser verarbeitet. Es erfolgt keine Übertragung der hochgeladenen Inhalte an einen
-        Server der Anwendung.
+        Wenn Nutzer in der Anwendung CSV-Dateien exportieren, erfolgt die Erstellung der Datei ausschließlich lokal im
+        Browser. Es werden keine Inhaltsdaten des Exports an einen Server der Anwendung übertragen.
       </p>
       <p>
         <strong>Zweck:</strong> Bereitstellung der vom Nutzer angeforderten Viewer-Funktion.

--- a/src/components/OverflowMenu.test.tsx
+++ b/src/components/OverflowMenu.test.tsx
@@ -17,7 +17,6 @@ describe("OverflowMenu", () => {
     expect(html).toContain("Daten");
     expect(html).not.toContain("Info");
     expect(html).not.toContain("CSV exportieren");
-    expect(html).not.toContain("JSON laden");
     expect(html).not.toContain("Quellen &amp; Version");
     expect(html).not.toContain("About");
     expect(html).not.toContain("Dunkelmodus");

--- a/src/components/StatusToast.tsx
+++ b/src/components/StatusToast.tsx
@@ -4,7 +4,7 @@ interface StatusToastProps {
 }
 
 /**
- * Lightweight status toast for connectivity and import/export feedback.
+ * Lightweight status toast for connectivity and export feedback.
  * REQ: PD-09, PERF-04, C-08
  */
 export function StatusToast({ message, tone = "info" }: StatusToastProps) {

--- a/src/lib/dataSchemas.test.ts
+++ b/src/lib/dataSchemas.test.ts
@@ -5,8 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   CatalogIndexSchema,
   CatalogMetaSchema,
-  DetailChunkSchema,
-  UploadCatalogSchema
+  DetailChunkSchema
 } from "./dataSchemas";
 import { validateOrThrow } from "./validation";
 import { SECURITY_BUDGETS } from "./securityBudgets";
@@ -42,21 +41,6 @@ describe("schema validation", () => {
     expect(() => validateOrThrow(index, CatalogIndexSchema, "index")).not.toThrow();
     expect(() => validateOrThrow(meta, CatalogMetaSchema, "meta")).not.toThrow();
     expect(() => validateOrThrow(detailChunk, DetailChunkSchema, "detail")).not.toThrow();
-  });
-
-  it("lehnt ungueltigen Upload ab", () => {
-    const invalidUpload = { catalog: { groups: "not-an-array" } };
-    expect(() => validateOrThrow(invalidUpload, UploadCatalogSchema, "upload")).toThrow();
-  });
-
-  it("lehnt Upload ohne Kernfelder fail-closed ab", () => {
-    const missingGroupTitle = {
-      catalog: {
-        metadata: { title: "Test" },
-        groups: [{ id: "G-1" }]
-      }
-    };
-    expect(() => validateOrThrow(missingGroupTitle, UploadCatalogSchema, "upload-missing-title")).toThrow();
   });
 
   it("lehnt uebergrossen Index fail-closed ab", () => {

--- a/src/lib/dataSchemas.ts
+++ b/src/lib/dataSchemas.ts
@@ -20,7 +20,7 @@ const BuildInfoSchema = z
     datasetLabel: mediumString.optional(),
     catalogFileName: shortString,
     catalogFileSha256: z.string().regex(/^[a-f0-9]{64}$/i),
-    catalogFileSizeBytes: z.number().int().nonnegative().max(SECURITY_BUDGETS.maxUploadFileSizeBytes)
+    catalogFileSizeBytes: z.number().int().nonnegative().max(SECURITY_BUDGETS.maxCatalogFileSizeBytes)
   })
   .strict();
 
@@ -241,114 +241,6 @@ export const DetailChunkSchema = z
       });
     }
   });
-
-const UploadPropSchema = z
-  .object({
-    name: shortString.optional(),
-    ns: mediumString.optional(),
-    value: z.union([shortString, mediumString, longString, z.number(), z.boolean(), z.null()]).optional()
-  })
-  .passthrough();
-
-const UploadLinkSchema = z
-  .object({
-    href: mediumString,
-    rel: shortString.optional()
-  })
-  .passthrough();
-
-const UploadPartSchema: z.ZodTypeAny = z.lazy(() =>
-  z
-    .object({
-      id: shortString.optional(),
-      name: shortString,
-      prose: longString.optional(),
-      props: boundedArray(UploadPropSchema, SECURITY_BUDGETS.maxPropsPerControl).optional(),
-      parts: boundedArray(UploadPartSchema, SECURITY_BUDGETS.maxPartsPerControl).optional()
-    })
-    .passthrough()
-);
-
-const UploadParamSchema = z
-  .object({
-    id: shortString.optional(),
-    label: mediumString.optional(),
-    values: boundedArray(mediumString, 128).optional(),
-    props: boundedArray(UploadPropSchema, SECURITY_BUDGETS.maxPropsPerControl).optional()
-  })
-  .passthrough();
-
-const UploadControlSchema: z.ZodTypeAny = z.lazy(() =>
-  z
-    .object({
-      id: shortString,
-      title: mediumString.optional(),
-      class: shortString.optional(),
-      props: boundedArray(UploadPropSchema, SECURITY_BUDGETS.maxPropsPerControl).optional(),
-      params: boundedArray(UploadParamSchema, SECURITY_BUDGETS.maxParamsPerControl).optional(),
-      parts: boundedArray(UploadPartSchema, SECURITY_BUDGETS.maxPartsPerControl).optional(),
-      links: boundedArray(UploadLinkSchema, SECURITY_BUDGETS.maxLinksPerControl).optional(),
-      controls: boundedArray(UploadControlSchema, SECURITY_BUDGETS.maxControlCount).optional()
-    })
-    .passthrough()
-);
-
-const UploadGroupSchema: z.ZodTypeAny = z.lazy(() =>
-  z
-    .object({
-      id: shortString,
-      title: mediumString,
-      props: boundedArray(UploadPropSchema, SECURITY_BUDGETS.maxPropsPerControl).optional(),
-      controls: boundedArray(UploadControlSchema, SECURITY_BUDGETS.maxControlCount).optional(),
-      groups: boundedArray(UploadGroupSchema, SECURITY_BUDGETS.maxGroupCount).optional()
-    })
-    .passthrough()
-);
-
-const UploadCatalogBodySchema = z
-  .object({
-    uuid: shortString.optional(),
-    metadata: z
-      .object({
-        title: mediumString.optional(),
-        version: shortString.optional(),
-        remarks: longString.optional(),
-        "last-modified": shortString.optional(),
-        "oscal-version": shortString.optional(),
-        props: boundedArray(UploadPropSchema, SECURITY_BUDGETS.maxPropsPerControl).optional(),
-        links: boundedArray(
-          z
-            .object({
-              href: mediumString,
-              rel: shortString.optional()
-            })
-            .passthrough(),
-          SECURITY_BUDGETS.maxLinksPerControl
-        ).optional(),
-        parties: boundedArray(z.unknown(), 64).optional(),
-        "responsible-parties": boundedArray(z.unknown(), 64).optional()
-      })
-      .passthrough()
-      .optional(),
-    "back-matter": z
-      .object({
-        resources: boundedArray(z.unknown(), 2_000).optional()
-      })
-      .passthrough()
-      .optional(),
-    groups: z.array(UploadGroupSchema).min(1).max(SECURITY_BUDGETS.maxGroupCount)
-  })
-  .passthrough();
-
-const UploadCatalogRootSchema = z
-  .object({
-    catalog: UploadCatalogBodySchema
-  })
-  .strict();
-
-const UploadCatalogDirectSchema = UploadCatalogBodySchema;
-
-export const UploadCatalogSchema = z.union([UploadCatalogRootSchema, UploadCatalogDirectSchema]);
 
 export const NormalizedCatalogSchema = z
   .object({

--- a/src/lib/searchClient.ts
+++ b/src/lib/searchClient.ts
@@ -142,14 +142,6 @@ export class SearchClient {
     return this.request<RelationGraphPayload>("get-neighborhood", { id, hops }, 15000);
   }
 
-  loadUpload(rawText: string) {
-    return this.request<{
-      meta: Partial<CatalogMeta>;
-      facetOptions: any;
-      stats: CatalogMeta["stats"];
-    }>("load-upload", { rawText }, 45000);
-  }
-
   destroy() {
     this.rejectAllPending(new Error("Worker wurde beendet."));
     this.worker.terminate();

--- a/src/lib/securityBudgets.ts
+++ b/src/lib/securityBudgets.ts
@@ -1,5 +1,5 @@
 export const SECURITY_BUDGETS = {
-  maxUploadFileSizeBytes: 8 * 1024 * 1024,
+  maxCatalogFileSizeBytes: 8 * 1024 * 1024,
   maxRemoteJsonBytes: {
     catalogIndex: 3 * 1024 * 1024,
     catalogMeta: 1 * 1024 * 1024,
@@ -23,6 +23,5 @@ export const SECURITY_BUDGETS = {
   maxRelationsPerControl: 512,
   maxPathDepth: 64,
   searchTimeBudgetMs: 2_500,
-  uploadIngestionBudgetMs: 8_000,
   searchCheckpointInterval: 100
 } as const;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1608,26 +1608,6 @@ summary:focus-visible,
   flex: 0 0 auto;
 }
 
-.app-footer-link-button {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  color: var(--link);
-  font: inherit;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 0.14rem;
-  text-decoration-thickness: 0.08rem;
-}
-
-.app-footer-link-button:disabled {
-  color: var(--link);
-  opacity: 1;
-  cursor: default;
-}
-
 .section-heading-row {
   display: flex;
   align-items: center;

--- a/src/workers/searchWorker.ts
+++ b/src/workers/searchWorker.ts
@@ -3,18 +3,14 @@
 import {
   CatalogIndexSchema,
   DetailChunkSchema,
-  NormalizedCatalogSchema,
-  UploadCatalogSchema,
   type CatalogIndexPayloadValidated
 } from "../lib/dataSchemas";
 import { fetchJsonWithValidation } from "../lib/fetchJsonSafe";
-import { normalizeCatalog } from "../lib/normalize-core.js";
 import { limitQueryTokens, sanitizeSearchText } from "../lib/searchSafety";
 import { SECURITY_BUDGETS } from "../lib/securityBudgets";
 import { makeSnippet, normalizeGerman, tokenize } from "../lib/text";
-import { assertByteBudget, parseJsonOrThrow, validateOrThrow } from "../lib/validation";
+import { validateOrThrow } from "../lib/validation";
 import type {
-  CatalogMeta as CatalogMetaType,
   ControlDetail,
   RelationGraphPayload,
   SearchDoc,
@@ -36,7 +32,7 @@ type IndexedDoc = SearchDoc & {
 };
 
 type WorkerRequest = {
-  type: "init" | "search" | "get-control" | "get-neighborhood" | "load-upload" | "cancel";
+  type: "init" | "search" | "get-control" | "get-neighborhood" | "cancel";
   requestId: string;
   payload?: any;
 };
@@ -597,50 +593,6 @@ async function handleRequest(request: WorkerRequest): Promise<any> {
       throw new Error("Control-ID fehlt.");
     }
     return buildNeighborhoodGraph(controlId, hops, request.requestId);
-  }
-
-  if (request.type === "load-upload") {
-    const startedAt = performance.now();
-    assertRequestNotCancelled(request.requestId);
-    const rawText = String(request.payload?.rawText ?? "");
-    assertByteBudget(rawText, SECURITY_BUDGETS.maxUploadFileSizeBytes, "Upload-Datei");
-
-    const parsed = parseJsonOrThrow(rawText, "Upload-Datei");
-    const validatedInput = validateOrThrow(parsed, UploadCatalogSchema, "Upload-Katalogstruktur");
-
-    await checkpoint(request.requestId, startedAt, "Upload-Validierung", SECURITY_BUDGETS.uploadIngestionBudgetMs);
-    const normalized = normalizeCatalog(validatedInput);
-    await checkpoint(request.requestId, startedAt, "Upload-Normalisierung", SECURITY_BUDGETS.uploadIngestionBudgetMs);
-    const validatedNormalized = validateOrThrow(normalized, NormalizedCatalogSchema, "Upload-Kataloginhalt");
-
-    setIndexedDocs(validatedNormalized.docs as SearchDoc[]);
-    facetOptions = computeFacetOptions(validatedNormalized.docs as SearchDoc[]);
-    detailChunks.clear();
-    inlineDetails.clear();
-
-    let importedControls = 0;
-    for (const chunk of Object.values(validatedNormalized.detailsByTopGroup) as Array<{ controls: Record<string, ControlDetail> }>) {
-      for (const [id, detail] of Object.entries(chunk.controls)) {
-        inlineDetails.set(id, detail);
-        importedControls += 1;
-        if (importedControls % SECURITY_BUDGETS.searchCheckpointInterval === 0) {
-          await checkpoint(request.requestId, startedAt, "Upload-Indexierung", SECURITY_BUDGETS.uploadIngestionBudgetMs);
-        }
-      }
-    }
-
-    const meta = {
-      ...validatedNormalized.meta,
-      stats: validatedNormalized.stats as CatalogMetaType["stats"],
-      groups: validatedNormalized.groups as CatalogMetaType["groups"],
-      groupTree: validatedNormalized.groupTree as CatalogMetaType["groupTree"]
-    } as Partial<CatalogMetaType>;
-
-    return {
-      facetOptions,
-      meta,
-      stats: validatedNormalized.stats
-    };
   }
 
   throw new Error(`Unbekannter Request-Typ: ${request.type}`);


### PR DESCRIPTION
## Summary
- remove the "JSON laden" UI action and file input from the footer
- remove the upload handling flow from the app, worker client, and worker protocol
- remove upload-specific schemas, budgets, tests, and stale UI assertions
- update documentation and Datenschutzerklaerung to reflect that JSON import is no longer supported

## Validation
- npm run build:data
- npm run test:unit
- npm run build
- npm run check:release-hygiene

## Notes
- no changes to public/data/** were introduced by this change
- GitHub Pages behavior is unchanged