### PR TITLE
fix: harden CSV neutralization and add security audit report

### DIFF
--- a/security-audit-report.md
+++ b/security-audit-report.md
@@ -1,0 +1,134 @@
+# Security Audit Report — bsi-grundschutz-plusplus-viewer
+**Datum:** 2026-03-09
+**Scope:** Supply Chain · XSS/Injection · CSV-Export · Service Worker · CI/CD
+**Gesamt-Risikoeinschätzung:** MITTEL
+
+## Executive Summary
+Die Anwendung zeigt insgesamt eine solide Sicherheitsbasis (Schema-Validierung, URL-Härtung, Worker-Budgets, restriktive Link-Behandlung). Im Audit wurde jedoch ein **HOCH**-Finding im CSV-Export identifiziert: die Formel-Neutralisierung war unvollständig und ließ Umgehungen über führende Whitespaces/Steuerzeichen zu. Dieses Finding wurde im Rahmen dieses Audits direkt im Code behoben und per Unit-Tests abgesichert. Verbleibende Hauptrisiken liegen aktuell im Bereich CI/CD-Härtung (Action-Pinning, minimale Token-Rechte) und fehlender CSP.
+
+## Findings
+
+### FINDING-001 — Unvollständige CSV-Formelneutralisierung (umgehbar)
+| Attribut | Wert |
+|---|---|
+| Schweregrad | HOCH |
+| Kategorie | CSV |
+| Betroffene Datei(en) | `src/lib/csv.ts`, `src/lib/csv.test.ts` |
+| Zeile(n) | L28–L49, L43–L66 |
+| CVE (falls zutreffend) | - |
+
+**Beschreibung:**
+Die ursprüngliche Neutralisierung prüfte nur direkte Präfixe (`=`, `+`, `-`, `@`) am Stringanfang. Dadurch waren Umgehungen über führende Whitespaces, Steuerzeichen (`\t`, `\r`), Pipe-Prefix (`|`) und Unicode-Varianten möglich. Der Fix wurde umgesetzt: er erkennt jetzt führende Steuerzeichen, trimmt sicherheitsrelevante führende Zeichen, normalisiert per `NFKC` und neutralisiert erweiterte Präfixe. Regressionstests decken die Edge-Cases ab.
+
+**Angriffsszenario:**
+Ein manipulierter Katalogeintrag (z. B. über kompromittierte Upstream-Daten) kann Exportfelder so präparieren, dass Tabellenkalkulationen trotz vermeintlicher Härtung Formeln interpretieren. Beim Öffnen der CSV in Excel/LibreOffice kann dies zu ungewollten Berechnungen, externen Verweisen oder DDE-nahen Missbrauchspfaden führen. Der Angriff benötigt Nutzerinteraktion (CSV öffnen), ist aber realistisch im operativen Workflow.
+
+**Empfehlung:**
+Fix beibehalten (bereits umgesetzt), Testabdeckung für weitere Spreadsheet-Parser-Varianten fortlaufend erweitern und CSV-Härtung als Security-Gate in CI belassen.
+
+---
+
+### FINDING-002 — Keine Content Security Policy (CSP) im ausgelieferten HTML
+| Attribut | Wert |
+|---|---|
+| Schweregrad | MITTEL |
+| Kategorie | XSS |
+| Betroffene Datei(en) | `index.html` |
+| Zeile(n) | L3–L8 |
+| CVE (falls zutreffend) | - |
+
+**Beschreibung:**
+Im statischen Einstiegspunkt fehlt eine CSP (`<meta http-equiv="Content-Security-Policy">`) und im Repository ist keine hostseitige Header-Policy für GitHub Pages konfigurierbar hinterlegt. Das ist kein direkter Exploit, reduziert aber die Abwehrtiefe gegen künftige XSS-Fehler erheblich.
+
+**Angriffsszenario:**
+Sollte künftig an anderer Stelle ein DOM-XSS eingeführt werden (z. B. durch unsichere Drittkomponente oder Renderpfad), kann fehlende CSP die Ausnutzung deutlich erleichtern. Besonders bei statischem Hosting ohne serverseitige Runtime-Guards fehlt damit ein wichtiger Containment-Mechanismus.
+
+**Empfehlung:**
+Eine explizite CSP definieren (mindestens `default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'`) und auf GitHub-Pages-kompatible Durchsetzung prüfen.
+
+---
+
+### FINDING-003 — GitHub Actions nicht auf Commit-SHA gepinnt
+| Attribut | Wert |
+|---|---|
+| Schweregrad | MITTEL |
+| Kategorie | CI/CD |
+| Betroffene Datei(en) | `.github/workflows/quality.yml`, `.github/workflows/deploy-pages.yml`, `.github/workflows/daily-bsi-sync.yml` |
+| Zeile(n) | quality.yml L26/L29, deploy-pages.yml L23/L26/L32/L50/L63, daily-bsi-sync.yml L33/L38/L85 |
+| CVE (falls zutreffend) | - |
+
+**Beschreibung:**
+Workflows referenzieren Actions über Major-Tags (`@v4`, `@v6`, `@v7`) statt unveränderlicher Commit-SHAs. Das ist branchenüblich, erhöht aber das Supply-Chain-Risiko gegenüber strikt gepinnten Referenzen.
+
+**Angriffsszenario:**
+Bei kompromittierter Action-Pipeline oder missbräuchlich verschobenen Tags könnte in CI/CD unerwarteter Code laufen. In Kombination mit schreibberechtigten Tokens (z. B. Sync-Workflow) kann das Auswirkungen auf Repository-Integrität haben.
+
+**Empfehlung:**
+Alle `uses:`-Einträge auf Commit-SHA pinnen und ein regelmäßiges Update-Verfahren etablieren (z. B. Dependabot für Actions mit Review-Pflicht).
+
+---
+
+### FINDING-004 — Fehlender `permissions`-Block im Quality-Workflow
+| Attribut | Wert |
+|---|---|
+| Schweregrad | MITTEL |
+| Kategorie | CI/CD |
+| Betroffene Datei(en) | `.github/workflows/quality.yml` |
+| Zeile(n) | L1–L44 |
+| CVE (falls zutreffend) | - |
+
+**Beschreibung:**
+Der Workflow `quality.yml` definiert keinen expliziten `permissions`-Block. Damit hängt der effektive Scope vom Repository-Default ab und kann weiter reichen als für reine QA-Jobs erforderlich.
+
+**Angriffsszenario:**
+Falls ein Build-/Testschritt oder eine Dependency kompromittiert wird, erhöht ein zu breit berechtigtes `GITHUB_TOKEN` den möglichen Impact (z. B. Schreiboperationen statt reinem Lesen).
+
+**Empfehlung:**
+`permissions` explizit minimal setzen (für QA i. d. R. `contents: read` ausreichend).
+
+---
+
+### FINDING-005 — Dev-Dependency Advisory in `tmp` (transitiv via LHCI)
+| Attribut | Wert |
+|---|---|
+| Schweregrad | NIEDRIG |
+| Kategorie | Supply Chain |
+| Betroffene Datei(en) | `package-lock.json`, `package.json` |
+| Zeile(n) | package-lock.json L930–L949, L3291–L3299, L6042–L6050; package.json L27–L38 |
+| CVE (falls zutreffend) | GHSA-52f5-9888-hmc6 (kein CVE zugeordnet) |
+
+**Beschreibung:**
+`npm audit --json` meldet eine Low-Severity-Schwachstelle in `tmp` (`<=0.2.3`), transitiv über `@lhci/cli`/`inquirer`/`external-editor`. Produktionsabhängigkeiten (`npm audit --omit=dev`) sind ohne Befund.
+
+**Angriffsszenario:**
+Der Pfad betrifft primär Dev-/CI-Kontext. Auf gemeinsam genutzten Runnern kann ein lokaler Symlink-Angriff auf temporäre Dateien theoretisch möglich sein, in isolierten CI-Umgebungen ist das Risiko begrenzt.
+
+**Empfehlung:**
+Upstream-Updates von `@lhci/cli` beobachten bzw. Alternative für Lighthouse-Ausführung prüfen; Risiko bis dahin als Dev-Only akzeptieren und dokumentieren.
+
+---
+
+### FINDING-006 — Service Worker cached Katalogdaten dauerhaft clientseitig
+| Attribut | Wert |
+|---|---|
+| Schweregrad | INFO |
+| Kategorie | ServiceWorker |
+| Betroffene Datei(en) | `public/sw.js`, `src/main.tsx` |
+| Zeile(n) | sw.js L7–L9, L146–L155; main.tsx L23–L52 |
+| CVE (falls zutreffend) | - |
+
+**Beschreibung:**
+Der Service Worker cached HTML, JSON-Daten und Assets lokal (`Cache Storage`). Das ist funktional beabsichtigt und ohne direkten Sicherheitsfehler implementiert (same-origin, Response-Checks, Versionierung). Es bleibt jedoch ein Betriebsaspekt: Daten verbleiben bis zur Cache-Rotation auf Endgeräten.
+
+**Angriffsszenario:**
+Bei geteilten/unsicheren Endgeräten können lokal gecachte Inhalte länger verfügbar bleiben, selbst wenn sie serverseitig bereits ersetzt wurden. Das betrifft primär Datenschutz-/Betriebstransparenz, nicht unmittelbar Codeausführung.
+
+**Empfehlung:**
+Datenschutz-/Betriebshinweise beibehalten und optional eine UI-Funktion zum aktiven Cache-Reset ergänzen.
+
+---
+
+## Nicht untersuchte Bereiche
+- Reale Response-Header und CSP-Durchsetzung auf produktivem GitHub-Pages-Endpoint (nur Repository-Artefakte geprüft).
+- Laufzeitverhalten auf älteren Browsern und spezifischen Spreadsheet-Engines außerhalb der vorhandenen Unit-Tests.
+- Organisatorische GitHub-Repository-Einstellungen außerhalb der Workflow-Dateien (Rulesets, Branch Protection im UI).

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -40,6 +40,31 @@ describe("toCsv", () => {
     expect(csv).toBe(`value\r\n"'=HYPERLINK(""https://evil"")"`);
   });
 
+  it("neutralisiert gefaehrliche Praefixe auch nach Whitespace und Unicode-Normalisierung", () => {
+    const csv = toCsv(
+      [{ value: "   =1+1" }, { value: "|cmd" }, { value: "＝1+1" }, { value: "'=SAFE" }],
+      [{ key: "value", header: "value" }],
+      { withBom: false }
+    );
+
+    const lines = csv.split("\r\n");
+    expect(lines[1]).toBe("'   =1+1");
+    expect(lines[2]).toBe("'|cmd");
+    expect(lines[3]).toBe("'＝1+1");
+    expect(lines[4]).toBe("'=SAFE");
+  });
+
+  it("neutralisiert Tab- und Carriage-Return-Praefixe", () => {
+    const csv = toCsv(
+      [{ value: "\t=1+1" }, { value: "\r=1+1" }],
+      [{ key: "value", header: "value" }],
+      { withBom: false }
+    );
+
+    expect(csv).toContain("value\r\n'\t=1+1\r\n");
+    expect(csv).toContain(`\r\n"'\r=1+1"`);
+  });
+
   it("unterstuetzt Semikolon als Delimiter fuer Excel-DE-Import", () => {
     const csv = toCsv(
       [

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -9,6 +9,9 @@ export interface CsvOptions {
   withBom?: boolean;
 }
 
+const DANGEROUS_FORMULA_PREFIXES = new Set(["=", "+", "-", "@", "|"]);
+const LEADING_IGNORED_CHARACTERS = /^[\uFEFF\s\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*/u;
+
 function normalizeCell(value: unknown): string {
   if (value == null) {
     return "";
@@ -26,7 +29,23 @@ function neutralizeSpreadsheetFormula(value: string): string {
   if (!value) {
     return value;
   }
-  return /^[=+\-@]/.test(value) ? `'${value}` : value;
+
+  // SEC-FIX: FINDING-001 — Neutralize spreadsheet formulas with leading whitespace/control chars and Unicode variants.
+  if (value.startsWith("\t") || value.startsWith("\r")) {
+    return `'${value}`;
+  }
+
+  const leadingStripped = value.replace(LEADING_IGNORED_CHARACTERS, "");
+  if (!leadingStripped) {
+    return value;
+  }
+
+  const normalized = leadingStripped.normalize("NFKC");
+  if (normalized.startsWith("'")) {
+    return value;
+  }
+
+  return DANGEROUS_FORMULA_PREFIXES.has(normalized[0]) ? `'${value}` : value;
 }
 
 function escapeCsvCell(value: string, delimiter: string): string {


### PR DESCRIPTION
## Summary
- harden CSV formula neutralization against leading whitespace/control chars, pipe prefix, and Unicode normalization bypasses
- add targeted regression tests for spreadsheet injection edge cases
- add a full German security audit report with evidence-based findings and recommendations

## Validation
- npm run test:unit:raw -- src/lib/csv.test.ts
- npm run test:unit:raw
- npm run build
- npm run check:release-hygiene
- npm audit --json
- npm audit --omit=dev --json
- npm outdated --json

## Notes
- No production dependency vulnerabilities reported by npm audit --omit=dev
- One low-severity dev-only advisory remains in transitive tmp (via @lhci/cli), documented in the report