### PR TITLE
test: implement phase-a core logic coverage measures

### DIFF
--- a/docs/coverage-phase-a-implementation.md
+++ b/docs/coverage-phase-a-implementation.md
@@ -1,0 +1,99 @@
+# Coverage Phase A Implementation (2026-03-09)
+
+## 1. Kurzueberblick der umgesetzten Phase-A-Massnahmen
+
+Auf Basis der vorhandenen Analyse (`docs/qa-coverage-gap-analysis.md`) wurden die priorisierten, schnell umsetzbaren Unit-Tests fuer kritische pure Logik und fail-closed Fehlerpfade umgesetzt. Fokus war auf:
+
+- Input-Haertung und Budgetgrenzen
+- Textnormalisierung/Snippet-Verhalten fuer Suche
+- Validierungs- und Parsing-Fehlersemantik
+- sichere JSON-Fetch-Pfade mit Schema-Validierung
+- first-pass Fixture-Absicherung fuer Katalognormalisierung
+
+Keine produktive Fachlogik wurde geaendert.
+
+## 2. Welche Dateien/Module getestet wurden
+
+- `src/lib/searchSafety.ts` -> `src/lib/searchSafety.test.ts`
+- `src/lib/text.ts` -> `src/lib/text.test.ts`
+- `src/lib/validation.ts` -> `src/lib/validation.test.ts`
+- `src/lib/fetchJsonSafe.ts` -> `src/lib/fetchJsonSafe.test.ts`
+- `src/lib/normalize-core.js` -> `src/lib/normalize-core.test.ts`
+- `src/legal/placeholders.ts` -> `src/legal/placeholders.test.ts`
+
+## 3. Durchgefuehrte Refactorings und warum
+
+- Keine produktiven Refactorings notwendig.
+- Es wurde ausschliesslich Testcode hinzugefuegt.
+
+## 4. Welche Testfaelle hinzugefuegt wurden
+
+### `searchSafety`
+
+- Nicht-String-Input wird fail-closed zu leerem Suchtext.
+- Steuerzeichen-Entfernung, Trim und Zeichenlimit fuer Query.
+- Filterwert-Sanitizing: Leereintraege verwerfen, Einzellimit, Gesamtlimit.
+- Tokenlimit wird strikt angewendet.
+
+### `text`
+
+- Umlaute/Eszett/Akzent-Normalisierung.
+- Tokenisierung mit Ausschluss sehr kurzer Tokens.
+- Entfernung von Mustache-Inserts.
+- Snippet-Verhalten:
+  - leere Quelle nach Cleanup
+  - ohne Query-Tokens
+  - mit Treffer im Text (Prefix/Suffix-Ellipsen)
+  - ohne Treffer (Fallback auf Textanfang)
+
+### `validation`
+
+- Erfolgreiche Validierung mit Rueckgabe geparster Daten.
+- Fehlermeldungen mit Kontext und Pfad (`items[0].id`).
+- Zusammenfassung vieler Issues mit Suffix `(+N weitere)`.
+- JSON-Parsefehler mit Antwort-Snippet.
+- Byte-Budget (inkl. UTF-8 Mehrbytezeichen).
+
+### `fetchJsonSafe`
+
+- Erfolgsfall mit validierter JSON-Antwort.
+- HTTP-Fehlerpfad (`!response.ok`).
+- Content-Length-Fehlerpfad vor Body-Parsing.
+- JSON-Parsefehler.
+- Schema-Validierungsfehler.
+- Byte-Budget-Pruefung auch ohne `content-length`.
+
+### `normalize-core`
+
+- Guard-Fehler bei ungueltiger OSCAL-Struktur (`catalog.groups fehlt`).
+- Fixture-basierter End-to-End-Normalisierungsdurchlauf fuer:
+  - Metadaten inkl. Publisher-Aufloesung
+  - Source-Reference-Aufloesung aus `back-matter`
+  - Gruppenbaum
+  - Controls inkl. Tags/Modalverben/Target-Objects
+  - eingehende/ausgehende Relationen
+  - aggregierte Statistiken
+
+### `legal/placeholders`
+
+- Placeholder-Erkennung (`{{...}}`) true/false-Pfad.
+
+## 5. Welche Risiken bewusst noch offen bleiben
+
+- Worker-Protokoll und Suchkern in `src/workers/searchWorker.ts` bleiben weiterhin ohne dedizierte Unit-/Integrationstests.
+- `src/lib/searchClient.ts` Fehler-/Timeout-Lifecycle bleibt offen.
+- `src/App.tsx` Orchestrierungspfad (Hash/State/Flow) bleibt offen.
+- Coverage-Messung selbst ist weiterhin nicht aktiviert (fehlende `@vitest/coverage-v8` Dependency laut Analyse).
+
+## 6. Naechste Kandidaten fuer Phase B
+
+- `src/lib/searchClient.ts`: Timeout/Cancel/messageerror/Pending-Lifecycle.
+- `src/App.tsx`: Hash-State-Sync, Boot-Error-Pfade, CSV-Flow-Fehlerpfade.
+- `src/hooks/useFocusTrap.ts`: Tab-Zyklus, Shift+Tab, Fokus-Restore.
+- `src/components/ResultList.tsx` und `src/components/GroupPage.tsx`: Pagination/Selection/Empty-State.
+
+## 7. Qualitative Einordnung der verbesserten Prueftiefe
+
+- Die Suite deckt jetzt mehrere fachlich kritische und deterministische Kernpfade ab, die zuvor nur indirekt oder gar nicht geprueft waren.
+- Besonders bei Input-Sanitizing, Validierung, Fehlersemantik und Katalognormalisierung wurden Branches mit realem Regressionsnutzen geschlossen.
+- Es wurden keine kosmetischen Render-Tests ergaenzt; der Zugewinn liegt in inhaltlicher Prueftiefe, nicht in oberflaechlicher Coverage-Erhoehung.

--- a/src/legal/placeholders.test.ts
+++ b/src/legal/placeholders.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isPlaceholderValue } from "./placeholders";
+
+describe("isPlaceholderValue", () => {
+  it("returns true for template placeholders", () => {
+    expect(isPlaceholderValue("{{OPERATOR_NAME}}")).toBe(true);
+  });
+
+  it("returns false for normal values", () => {
+    expect(isPlaceholderValue("Example Operator GmbH")).toBe(false);
+  });
+});

--- a/src/lib/fetchJsonSafe.test.ts
+++ b/src/lib/fetchJsonSafe.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { fetchJsonWithValidation } from "./fetchJsonSafe";
+
+const TEST_SCHEMA = z.object({
+  ok: z.boolean()
+});
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetchWithResponse(response: Response) {
+  globalThis.fetch = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+}
+
+describe("fetchJsonWithValidation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it("returns validated json for successful response", async () => {
+    mockFetchWithResponse(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-length": "11" }
+      })
+    );
+
+    await expect(
+      fetchJsonWithValidation({
+        url: "/data/index.json",
+        label: "Index",
+        schema: TEST_SCHEMA,
+        maxBytes: 100
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/data/index.json");
+  });
+
+  it("fails closed on non-ok http status", async () => {
+    mockFetchWithResponse(new Response("Service unavailable", { status: 503 }));
+
+    await expect(
+      fetchJsonWithValidation({
+        url: "/data/index.json",
+        label: "Index",
+        schema: TEST_SCHEMA,
+        maxBytes: 100
+      })
+    ).rejects.toThrowError(/Index konnte nicht geladen werden \(HTTP 503\)\. URL: \/data\/index\.json/);
+  });
+
+  it("rejects when content-length exceeds byte budget", async () => {
+    mockFetchWithResponse(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-length": "1000" }
+      })
+    );
+
+    await expect(
+      fetchJsonWithValidation({
+        url: "/data/index.json",
+        label: "Index",
+        schema: TEST_SCHEMA,
+        maxBytes: 100
+      })
+    ).rejects.toThrowError(/Index ist zu gross \(Content-Length 1000 > 100 Bytes\)\. URL: \/data\/index\.json/);
+  });
+
+  it("rejects invalid json payloads", async () => {
+    mockFetchWithResponse(new Response("{ not-json", { status: 200 }));
+
+    await expect(
+      fetchJsonWithValidation({
+        url: "/data/index.json",
+        label: "Index",
+        schema: TEST_SCHEMA,
+        maxBytes: 100
+      })
+    ).rejects.toThrowError(/ist kein gueltiges JSON/);
+  });
+
+  it("rejects schema-invalid payloads", async () => {
+    mockFetchWithResponse(new Response('{"ok":"yes"}', { status: 200 }));
+
+    await expect(
+      fetchJsonWithValidation({
+        url: "/data/index.json",
+        label: "Index",
+        schema: TEST_SCHEMA,
+        maxBytes: 100
+      })
+    ).rejects.toThrowError(/ist ungueltig/);
+  });
+
+  it("enforces byte budget even when content-length is missing", async () => {
+    mockFetchWithResponse(new Response("0123456789ABCDEF", { status: 200 }));
+
+    await expect(
+      fetchJsonWithValidation({
+        url: "/data/index.json",
+        label: "Index",
+        schema: TEST_SCHEMA,
+        maxBytes: 8
+      })
+    ).rejects.toThrowError(/ueberschreitet Groessenbudget/);
+  });
+});

--- a/src/lib/normalize-core.test.ts
+++ b/src/lib/normalize-core.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCatalog } from "./normalize-core.js";
+
+const CATALOG_FIXTURE = {
+  catalog: {
+    uuid: "catalog-1",
+    metadata: {
+      title: "Fixture Catalog",
+      version: "2026.03",
+      "last-modified": "2026-03-09",
+      "oscal-version": "1.1.2",
+      remarks: "fixture metadata",
+      props: [{ name: "classification", value: "internal" }],
+      parties: [
+        {
+          uuid: "party-creator",
+          name: "Creator Org",
+          type: "organization",
+          "email-addresses": ["creator@example.org"]
+        },
+        {
+          uuid: "party-fallback",
+          name: "Fallback Org",
+          type: "organization",
+          "email-addresses": ["fallback@example.org"]
+        }
+      ],
+      "responsible-parties": [{ "role-id": "creator", "party-uuids": ["party-creator"] }],
+      links: [{ rel: "source", href: "#resource-1" }]
+    },
+    "back-matter": {
+      resources: [
+        {
+          uuid: "resource-1",
+          title: "Source PDF",
+          description: "primary source",
+          rlinks: [
+            {
+              href: "https://example.org/source.pdf",
+              hashes: [{ algorithm: "sha-256", value: "abc123" }]
+            }
+          ]
+        }
+      ]
+    },
+    groups: [
+      {
+        id: "OPS",
+        title: "Operations",
+        props: [
+          { name: "alt-identifier", value: "OPS-A" },
+          { name: "label", value: "Operations Label" }
+        ],
+        controls: [
+          {
+            id: "OPS.1",
+            title: "Control One",
+            class: "technical",
+            props: [
+              { name: "tags", value: "alpha, beta" },
+              { name: "sec_level", value: "high" },
+              { name: "effort_level", value: "medium" }
+            ],
+            params: [
+              {
+                id: "param-1",
+                label: "Interval",
+                values: ["monthly"],
+                props: [{ name: "source", value: "fixture" }]
+              }
+            ],
+            parts: [
+              {
+                id: "part-1",
+                name: "statement",
+                prose: "Statement text",
+                props: [
+                  { name: "modalverb", value: "MUST" },
+                  { name: "target_objects", value: "Server, Client" }
+                ]
+              },
+              {
+                id: "part-2",
+                name: "guidance",
+                prose: "Guidance text",
+                props: [{ name: "modalverb", value: "MUST" }]
+              }
+            ],
+            links: [{ rel: "required", href: "#OPS.2" }],
+            controls: [
+              {
+                id: "OPS.1.1",
+                title: "Control Child",
+                props: [{ name: "tags", value: "child" }],
+                parts: [{ name: "statement", prose: "Child statement text" }]
+              }
+            ]
+          }
+        ],
+        groups: [
+          {
+            id: "OPS-SUB",
+            title: "Subgroup",
+            controls: [
+              {
+                id: "OPS.2",
+                title: "Control Two",
+                parts: [{ name: "statement", prose: "Second statement text" }],
+                links: [{ rel: "related", href: "https://example.org/external" }]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+};
+
+describe("normalizeCatalog", () => {
+  it("throws for invalid catalog structure", () => {
+    expect(() => normalizeCatalog({ catalog: {} })).toThrowError(
+      /Ungueltiges OSCAL-Katalogformat: catalog\.groups fehlt\./
+    );
+  });
+
+  it("normalizes metadata, groups, controls and relations", () => {
+    const normalized = normalizeCatalog(CATALOG_FIXTURE);
+
+    expect(normalized.meta).toMatchObject({
+      catalogId: "catalog-1",
+      title: "Fixture Catalog",
+      version: "2026.03",
+      publisher: {
+        name: "Creator Org",
+        type: "organization",
+        email: "creator@example.org",
+        uuid: "party-creator"
+      }
+    });
+    expect(normalized.meta.sourceReferences).toEqual([
+      {
+        rel: "source",
+        href: "#resource-1",
+        targetUuid: "resource-1",
+        title: "Source PDF",
+        description: "primary source",
+        resolvedHref: "https://example.org/source.pdf",
+        hashAlgorithm: "sha-256",
+        hashValue: "abc123"
+      }
+    ]);
+
+    expect(normalized.groups).toHaveLength(2);
+    expect(normalized.groupTree).toEqual([
+      {
+        id: "OPS",
+        title: "Operations",
+        topGroupId: "OPS",
+        children: [{ id: "OPS-SUB", title: "Subgroup", topGroupId: "OPS", children: [] }]
+      }
+    ]);
+
+    expect(normalized.docs).toHaveLength(3);
+    expect(normalized.stats).toEqual({
+      topGroupCount: 1,
+      groupCount: 2,
+      controlCount: 3,
+      relationCount: 1,
+      controlsWithRelations: 2
+    });
+
+    const opsTopGroup = normalized.detailsByTopGroup.OPS;
+    expect(opsTopGroup).toBeDefined();
+    expect(Object.keys(opsTopGroup.controls)).toEqual(["OPS.1", "OPS.1.1", "OPS.2"]);
+
+    const controlOne = opsTopGroup.controls["OPS.1"];
+    expect(controlOne.tags).toEqual(["alpha", "beta"]);
+    expect(controlOne.modalverbs).toEqual(["MUST"]);
+    expect(controlOne.targetObjects).toEqual(["Server", "Client"]);
+    expect(controlOne.relationsOutgoing).toEqual([
+      { sourceControlId: "OPS.1", targetControlId: "OPS.2", relType: "required" }
+    ]);
+
+    const controlTwo = opsTopGroup.controls["OPS.2"];
+    expect(controlTwo.relationsIncoming).toEqual([
+      { sourceControlId: "OPS.1", targetControlId: "OPS.2", relType: "required" }
+    ]);
+  });
+});

--- a/src/lib/searchSafety.test.ts
+++ b/src/lib/searchSafety.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { limitQueryTokens, sanitizeFilterValues, sanitizeSearchText } from "./searchSafety";
+import { SECURITY_BUDGETS } from "./securityBudgets";
+
+describe("sanitizeSearchText", () => {
+  it("returns empty string for non-string inputs", () => {
+    expect(sanitizeSearchText(null)).toBe("");
+    expect(sanitizeSearchText(undefined)).toBe("");
+    expect(sanitizeSearchText(42 as unknown as string)).toBe("");
+  });
+
+  it("removes control chars, trims and enforces max length", () => {
+    const overlong = `\u0000  abc\u001F${"x".repeat(SECURITY_BUDGETS.maxQueryChars + 25)}  `;
+    const sanitized = sanitizeSearchText(overlong);
+
+    expect(sanitized.startsWith("abc")).toBe(true);
+    expect(sanitized.length).toBe(SECURITY_BUDGETS.maxQueryChars);
+    expect(/[\u0000-\u001F\u007F]/.test(sanitized)).toBe(false);
+  });
+
+  it("returns empty string when only whitespace/control chars remain", () => {
+    expect(sanitizeSearchText(" \u0000 \u001F ")).toBe("");
+  });
+});
+
+describe("sanitizeFilterValues", () => {
+  it("returns empty array for invalid or empty input", () => {
+    expect(sanitizeFilterValues("not-an-array" as unknown as string[])).toEqual([]);
+    expect(sanitizeFilterValues([])).toEqual([]);
+  });
+
+  it("sanitizes values, drops empty entries and clips each value", () => {
+    const clipped = "x".repeat(SECURITY_BUDGETS.maxShortTextChars + 10);
+    const values = ["  alpha  ", "\u0000beta\u001F", "   ", null as unknown as string, clipped];
+    const sanitized = sanitizeFilterValues(values);
+
+    expect(sanitized).toEqual([
+      "alpha",
+      "beta",
+      "x".repeat(SECURITY_BUDGETS.maxShortTextChars)
+    ]);
+  });
+
+  it("enforces max item count", () => {
+    const values = Array.from({ length: SECURITY_BUDGETS.maxArrayItems + 7 }, (_, index) => `value-${index}`);
+    const sanitized = sanitizeFilterValues(values);
+
+    expect(sanitized).toHaveLength(SECURITY_BUDGETS.maxArrayItems);
+    expect(sanitized[sanitized.length - 1]).toBe(`value-${SECURITY_BUDGETS.maxArrayItems - 1}`);
+  });
+});
+
+describe("limitQueryTokens", () => {
+  it("clips tokens to the configured max token budget", () => {
+    const tokens = Array.from({ length: SECURITY_BUDGETS.maxQueryTokens + 3 }, (_, index) => `t${index}`);
+    expect(limitQueryTokens(tokens)).toEqual(tokens.slice(0, SECURITY_BUDGETS.maxQueryTokens));
+  });
+});

--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { makeSnippet, normalizeGerman, stripMustacheInserts, tokenize } from "./text";
+
+describe("normalizeGerman", () => {
+  it("normalizes umlauts, sharp-s and accents", () => {
+    expect(normalizeGerman("Aerger ueber Oel, Fußwege und Cafe")).toBe(
+      "aerger ueber oel fusswege und cafe"
+    );
+  });
+
+  it("removes unsupported punctuation and normalizes whitespace", () => {
+    expect(normalizeGerman("  RISK#1 !!!   alpha---beta  ")).toBe("risk#1 alpha---beta");
+  });
+});
+
+describe("tokenize", () => {
+  it("returns normalized tokens and drops one-character tokens", () => {
+    expect(tokenize("A b C1 C #ID foo-bar")).toEqual(["c1", "#id", "foo-bar"]);
+  });
+});
+
+describe("stripMustacheInserts", () => {
+  it("removes insert placeholders from text", () => {
+    expect(stripMustacheInserts("Text {{ insert: param, P1 }} Ende")).toBe("Text  Ende");
+  });
+});
+
+describe("makeSnippet", () => {
+  it("returns empty string when source is empty after cleanup", () => {
+    expect(makeSnippet(" {{ insert: param, P1 }} ", ["test"])).toBe("");
+  });
+
+  it("returns leading snippet when query has no tokens", () => {
+    expect(makeSnippet("abcdefghijklmnop", [], 8)).toBe("abcdefgh");
+  });
+
+  it("centers around first matching query token where possible", () => {
+    const source = "eins zwei drei vier fuenf sechs sieben acht neun";
+    const snippet = makeSnippet(source, ["fuenf"], 16);
+
+    expect(snippet.startsWith("…")).toBe(true);
+    expect(snippet.endsWith("…")).toBe(true);
+    expect(snippet).toContain("fuenf");
+  });
+
+  it("falls back to start of text when no token is found", () => {
+    expect(makeSnippet("eins zwei drei vier", ["nichtvorhanden"], 8)).toBe("eins zwe…");
+  });
+});

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { assertByteBudget, parseJsonOrThrow, validateOrThrow } from "./validation";
+
+describe("validateOrThrow", () => {
+  it("returns parsed data on successful validation", () => {
+    const schema = z.object({ id: z.string(), enabled: z.boolean() });
+    expect(validateOrThrow({ id: "A.1", enabled: true }, schema, "payload")).toEqual({
+      id: "A.1",
+      enabled: true
+    });
+  });
+
+  it("includes context and nested path information for invalid payloads", () => {
+    const schema = z.object({
+      items: z.array(
+        z.object({
+          id: z.string().min(2),
+          count: z.number().int().positive()
+        })
+      )
+    });
+
+    expect(() =>
+      validateOrThrow(
+        {
+          items: [{ id: "", count: 0 }]
+        },
+        schema,
+        "search-index"
+      )
+    ).toThrowError(/search-index ist ungueltig: items\[0\]\.id:/);
+  });
+
+  it("summarizes long error lists with issue count suffix", () => {
+    const schema = z.object({
+      a: z.string(),
+      b: z.string(),
+      c: z.string(),
+      d: z.string(),
+      e: z.string(),
+      f: z.string()
+    });
+
+    expect(() => validateOrThrow({}, schema, "bulk")).toThrowError(/\(\+1 weitere\)/);
+  });
+});
+
+describe("parseJsonOrThrow", () => {
+  it("parses valid json", () => {
+    expect(parseJsonOrThrow('{"ok":true}', "meta")).toEqual({ ok: true });
+  });
+
+  it("throws with compact snippet for invalid json", () => {
+    expect(() => parseJsonOrThrow("{\n invalid json", "meta")).toThrowError(
+      /meta ist kein gueltiges JSON\. Antwortbeginn: \{ invalid json/
+    );
+  });
+});
+
+describe("assertByteBudget", () => {
+  it("does not throw when byte budget is within limit", () => {
+    expect(() => assertByteBudget("abc", 3, "text")).not.toThrow();
+  });
+
+  it("throws when utf-8 byte budget is exceeded", () => {
+    expect(() => assertByteBudget("€", 2, "utf8-check")).toThrowError(
+      /utf8-check ueberschreitet Groessenbudget \(3 > 2 Bytes\)\./
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement phase-A test measures from docs/qa-coverage-gap-analysis.md
- add deterministic unit tests for core utility/parsing/validation paths
- add fixture-based first-pass test for catalog normalization
- document implementation in docs/coverage-phase-a-implementation.md

## Files Added
- docs/coverage-phase-a-implementation.md
- src/lib/searchSafety.test.ts
- src/lib/text.test.ts
- src/lib/validation.test.ts
- src/lib/fetchJsonSafe.test.ts
- src/lib/normalize-core.test.ts
- src/legal/placeholders.test.ts

## Validation
- npm run test:unit:raw
- npm run build
- npm run test:unit:raw

## Notes
- no production behavior changes
- no coverage config changes in this PR
- no generated artifacts committed