### PR TITLE
test: implement phase b routing and integration test coverage

### DIFF
--- a/docs/coverage-phase-b-implementation.md
+++ b/docs/coverage-phase-b-implementation.md
@@ -1,0 +1,83 @@
+# Coverage Phase B Implementation (2026-03-09)
+
+## 1. Kurzueberblick der umgesetzten Phase-B-Massnahmen
+
+Phase B erweitert die Testtiefe gezielt in drei Bereichen:
+
+- Worker-nahe Integrationspfade im Request-Lifecycle (`SearchClient`)
+- Routing-/Navigationshärtung fuer Hash-Routen und Route-Parameter
+- UI-Zustandsdarstellung fuer relevante Interaktions- und Fehlerpfade in Ergebnis-/Gruppenlisten
+
+Es wurden keine breit angelegten E2E-Erweiterungen umgesetzt. Der Fokus lag auf stabilen, schnellen und fachlich aussagekraeftigen Unit-/Integrationstests im bestehenden Vitest-Setup.
+
+## 2. Welche Komponenten/Module getestet wurden
+
+- `src/lib/searchClient.ts` -> `src/lib/searchClient.test.ts`
+- `src/lib/routing.ts` -> Erweiterung in `src/lib/routing.test.ts`
+- `src/components/ResultList.tsx` -> `src/components/ResultList.test.tsx`
+- `src/components/GroupPage.tsx` -> `src/components/GroupPage.test.tsx`
+
+## 3. Welche Integrationsszenarien abgedeckt wurden
+
+### Worker-/Datenintegration (`SearchClient`)
+
+- Erfolgsfall: `search` liefert Worker-Response korrekt zurueck.
+- Zustandstransition: neue Suche bricht vorherige Suche kontrolliert ab (`cancel` + definierter Fehlerpfad).
+- Fehlerpfade: `messageerror` und Worker-Runtime-Error verwerfen alle offenen Requests fail-closed.
+- Timeout-Verhalten: Request wird nach Ablauf der Zeitgrenze mit klarer Fehlermeldung beendet.
+- Lifecycle-Ende: `destroy()` beendet Worker und rejectet offene Requests.
+
+### Routing-/Navigation
+
+- Ungueltige `sort`-Werte fallen auf `relevance` zurueck.
+- Ungueltige/leere Route-Parameter in `#/group/...` und `#/control/...` fallen auf Home zurueck.
+- Optionalparameter (`control`, `top`) werden sanitiziert.
+- Hash-Builder fuer Search/Group/Control (inkl. Encodings) wird abgesichert.
+- Parse/Build-Roundtrip fuer Search-Routen mit Query, Sortierung, Filtern und Detailkontext.
+
+### UI-/Zustandsdarstellung (komponentennah)
+
+- `ResultList`:
+  - Laden, Fehler, Empty-State mit/ohne aktive Filter
+  - Label-Logik fuer Select-All-Zustand
+  - initiales Paging (25 Items) inkl. "Mehr laden"-CTA
+  - Treffer-Markierung (`<mark>`) im Snippet
+- `GroupPage`:
+  - Fallback "Gruppe nicht gefunden"
+  - Ladezustand der Controls
+  - Untergruppen-/Controls-Rendering inkl. initialem Paging
+  - Label-Logik fuer Select-All-Zustand
+
+## 4. Welche Refactorings durchgefuehrt wurden und warum
+
+- Keine produktiven Refactorings notwendig.
+- Es wurden ausschliesslich Testdateien hinzugefuegt und bestehende Routing-Tests erweitert.
+
+## 5. Welche Risiken und Luecken weiterhin offen bleiben
+
+- `src/App.tsx` als zentrale Orchestrierung bleibt weiterhin ohne dedizierte Integrationstests mit echten UI-Events.
+- Worker-Implementierung `src/workers/searchWorker.ts` selbst ist weiterhin nicht direkt getestet (nur Client-seitiger Protokollpfad).
+- Hook-basierte Interaktionslogik (`useFocusTrap`, `useMediaQuery`, `useDebouncedValue`) ist weiterhin nicht domnah abgesichert.
+- Echte Browser-Interaktionen (Keyboard/Fokus/Modal-Trapping) liegen weiterhin primaer bei Playwright/A11y.
+
+## 6. Welche Themen in Phase C folgen sollten
+
+1. Direkte Tests fuer `src/workers/searchWorker.ts` (Search/Filter/Sort/Neighborhood/Cancel).
+2. App-Orchestrierungsnahe Integrationstests fuer Hash-Sync, Boot-Fehlerpfade, Back-to-results und CSV-Flow in `src/App.tsx`.
+3. Hook-/DOM-nahe Tests fuer Fokus- und Keyboard-Verhalten (`useFocusTrap`, Overlay/Sheets).
+4. Erweiterte Worker-Protokolltests fuer Last-/Abbruch-Szenarien (inkl. race conditions).
+
+## 7. Welche Testkommandos ausgefuehrt wurden und mit welchem Ergebnis
+
+- `npm run test:unit:raw`
+  - Ergebnis: erfolgreich
+  - 21 Testdateien, 86 Tests, alle gruen
+- `npm run test:unit`
+  - Ergebnis: erfolgreich
+  - beinhaltet `npm run build` + `npm run test:unit:raw`
+  - Build inkl. `build:data`, TypeScript-Build, Legal-Placeholder-Check und Vite-Build erfolgreich
+
+## Zusatz: Artefakte/Hosting
+
+- `public/data/**` wurden zur Laufzeit des Build-Schritts lokal neu generiert, aber nicht versionierte Build-Artefakte und daher ohne Git-Diff.
+- Keine Aenderung am GitHub-Pages-Verhalten.

--- a/src/components/GroupPage.test.tsx
+++ b/src/components/GroupPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GroupPage } from "./GroupPage";
+import type { GroupNode, SearchResultItem } from "../types";
+
+function createGroup(overrides?: Partial<GroupNode>): GroupNode {
+  return {
+    id: "APP.1",
+    title: "Applikationssicherheit",
+    altIdentifier: null,
+    label: null,
+    parentGroupId: "APP",
+    topGroupId: "APP",
+    pathIds: ["APP", "APP.1"],
+    pathTitles: ["Applikation", "Applikationssicherheit"],
+    depth: 2,
+    ...overrides
+  };
+}
+
+function createControl(id: string): SearchResultItem {
+  return {
+    id,
+    title: `Control ${id}`,
+    score: 1,
+    topGroupId: "APP",
+    groupId: "APP.1",
+    class: null,
+    secLevel: "normal",
+    effortLevel: "1",
+    modalverbs: ["MUSS"],
+    targetObjects: [],
+    tags: ["basis"],
+    snippet: "Control Beschreibung",
+    breadcrumbs: ["APP", "APP.1"]
+  };
+}
+
+function createControls(count: number): SearchResultItem[] {
+  return Array.from({ length: count }, (_, index) => createControl(`APP.${index + 1}`));
+}
+
+describe("GroupPage", () => {
+  it("zeigt Fehlerzustand wenn die Gruppe nicht aufgeloest werden kann", () => {
+    const html = renderToStaticMarkup(
+      <GroupPage
+        group={null}
+        subgroups={[]}
+        controls={[]}
+        selectedControlIds={new Set<string>()}
+        loading={false}
+        selectingAllControls={false}
+        allControlsSelected={false}
+        onOpenSubgroup={vi.fn()}
+        onOpenControl={vi.fn()}
+        onToggleControlSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("Gruppe nicht gefunden.");
+    expect(html).toContain("status-box error");
+  });
+
+  it("rendert Untergruppen, Controls und initiales Paging", () => {
+    const html = renderToStaticMarkup(
+      <GroupPage
+        group={createGroup()}
+        subgroups={[createGroup({ id: "APP.1.1", title: "Sichere Konfiguration", depth: 3 })]}
+        controls={createControls(30)}
+        selectedControlIds={new Set<string>(["APP.1"])}
+        loading={false}
+        selectingAllControls={false}
+        allControlsSelected={false}
+        onOpenSubgroup={vi.fn()}
+        onOpenControl={vi.fn()}
+        onToggleControlSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("APP.1 - Applikationssicherheit");
+    expect(html).toContain("Untergruppen");
+    expect(html).toContain("Sichere Konfiguration");
+    expect(html).toContain("APP.25");
+    expect(html).not.toContain("APP.26");
+    expect(html).toContain("Mehr laden");
+    expect(html).toContain("export-selected");
+  });
+
+  it("zeigt den Ladehinweis fuer Controls waehrend Gruppenabfrage", () => {
+    const html = renderToStaticMarkup(
+      <GroupPage
+        group={createGroup()}
+        subgroups={[]}
+        controls={[]}
+        selectedControlIds={new Set<string>()}
+        loading
+        selectingAllControls={false}
+        allControlsSelected={false}
+        onOpenSubgroup={vi.fn()}
+        onOpenControl={vi.fn()}
+        onToggleControlSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("Controls werden geladen…");
+  });
+
+  it("zeigt korrekte Label fuer Select-All in Gruppen", () => {
+    const baseProps = {
+      group: createGroup(),
+      subgroups: [],
+      controls: [createControl("APP.1")],
+      selectedControlIds: new Set<string>(),
+      loading: false,
+      onOpenSubgroup: vi.fn(),
+      onOpenControl: vi.fn(),
+      onToggleControlSelection: vi.fn(),
+      onSelectAllControls: vi.fn()
+    };
+
+    const selectingHtml = renderToStaticMarkup(
+      <GroupPage {...baseProps} selectingAllControls allControlsSelected={false} />
+    );
+    const selectedHtml = renderToStaticMarkup(
+      <GroupPage {...baseProps} selectingAllControls={false} allControlsSelected />
+    );
+
+    expect(selectingHtml).toContain("Alles auswählen...");
+    expect(selectedHtml).toContain("Alles abwählen");
+  });
+});

--- a/src/components/ResultList.test.tsx
+++ b/src/components/ResultList.test.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ResultList } from "./ResultList";
+import type { SearchResultItem } from "../types";
+
+function createItem(id: string, snippet = "Firewall Härtung erforderlich"): SearchResultItem {
+  return {
+    id,
+    title: `Titel ${id}`,
+    score: 1,
+    topGroupId: "APP",
+    groupId: "APP.1",
+    class: null,
+    secLevel: "hoch",
+    effortLevel: "2",
+    modalverbs: ["SOLL"],
+    targetObjects: [],
+    tags: ["netzwerk"],
+    snippet,
+    breadcrumbs: ["APP", "APP.1"]
+  };
+}
+
+function createItems(count: number): SearchResultItem[] {
+  return Array.from({ length: count }, (_, index) => createItem(`APP.${index + 1}`));
+}
+
+describe("ResultList", () => {
+  it("zeigt einen Ladezustand waehrend laufender Suche", () => {
+    const html = renderToStaticMarkup(
+      <ResultList
+        items={[]}
+        total={0}
+        query=""
+        selectedId={null}
+        selectedControlIds={new Set<string>()}
+        loading
+        error={null}
+        onSelect={vi.fn()}
+        onToggleSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+        selectingAllControls={false}
+        allControlsSelected={false}
+        hasActiveFilters={false}
+      />
+    );
+
+    expect(html).toContain("Index wird abgefragt…");
+    expect(html).toContain('data-search-results-focus="loading"');
+  });
+
+  it("zeigt Fehlerzustand fuer fehlgeschlagene Suche", () => {
+    const html = renderToStaticMarkup(
+      <ResultList
+        items={[]}
+        total={0}
+        query=""
+        selectedId={null}
+        selectedControlIds={new Set<string>()}
+        loading={false}
+        error="Worker ist nicht erreichbar."
+        onSelect={vi.fn()}
+        onToggleSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+        selectingAllControls={false}
+        allControlsSelected={false}
+        hasActiveFilters={false}
+      />
+    );
+
+    expect(html).toContain("Worker ist nicht erreichbar.");
+    expect(html).toContain('role="alert"');
+  });
+
+  it("zeigt Empty-State inkl. Filter-Reset nur bei aktiven Filtern", () => {
+    const html = renderToStaticMarkup(
+      <ResultList
+        items={[]}
+        total={0}
+        query="  Firewall  "
+        selectedId={null}
+        selectedControlIds={new Set<string>()}
+        loading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onToggleSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+        selectingAllControls={false}
+        allControlsSelected={false}
+        hasActiveFilters
+        onResetFilters={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("Keine Treffer");
+    expect(html).toContain("Keine Ergebnisse für „Firewall“.");
+    expect(html).toContain("Filter zurücksetzen");
+  });
+
+  it("rendert Ergebnisliste mit initialem Paging und Treffer-Markierung", () => {
+    const items = createItems(30);
+    const html = renderToStaticMarkup(
+      <ResultList
+        items={items}
+        total={30}
+        query="firewall"
+        selectedId="APP.2"
+        selectedControlIds={new Set<string>(["APP.1"])}
+        loading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onToggleSelection={vi.fn()}
+        onSelectAllControls={vi.fn()}
+        selectingAllControls={false}
+        allControlsSelected={false}
+        hasActiveFilters={false}
+      />
+    );
+
+    expect(html).toContain("30 Treffer");
+    expect(html).toContain("APP.1");
+    expect(html).toContain("APP.25");
+    expect(html).not.toContain("APP.26");
+    expect(html).toContain("Mehr laden");
+    expect(html).toContain("<mark>Firewall</mark>");
+    expect(html).toContain("export-selected");
+  });
+
+  it("zeigt korrekte Label fuer Select-All-Aktionen", () => {
+    const baseProps = {
+      items: [createItem("APP.1")],
+      total: 1,
+      query: "",
+      selectedId: null,
+      selectedControlIds: new Set<string>(),
+      loading: false,
+      error: null,
+      onSelect: vi.fn(),
+      onToggleSelection: vi.fn(),
+      onSelectAllControls: vi.fn(),
+      hasActiveFilters: false
+    };
+
+    const selectingHtml = renderToStaticMarkup(
+      <ResultList {...baseProps} selectingAllControls allControlsSelected={false} />
+    );
+    const selectedHtml = renderToStaticMarkup(
+      <ResultList {...baseProps} selectingAllControls={false} allControlsSelected />
+    );
+
+    expect(selectingHtml).toContain("Alles auswählen...");
+    expect(selectedHtml).toContain("Alles abwählen");
+  });
+});

--- a/src/lib/routing.test.ts
+++ b/src/lib/routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseHash } from "./routing";
+import { buildControlHash, buildGroupHash, buildSearchHash, defaultFilters, parseHash } from "./routing";
 import { safeDecodeURIComponent } from "./safeDecode";
 import { SECURITY_BUDGETS } from "./securityBudgets";
 
@@ -50,6 +50,76 @@ describe("parseHash hardening", () => {
       if (route.view === "search") {
         expect(route.sort).toBe(expectedSort);
       }
+    }
+  });
+
+  it("faellt bei ungueltiger Sortierung auf relevance zurueck", () => {
+    const route = parseHash("#/search?sort=totally-invalid");
+    expect(route.view).toBe("search");
+    if (route.view === "search") {
+      expect(route.sort).toBe("relevance");
+    }
+  });
+
+  it("faengt ungueltige oder leere Parameter bei Group/Control-Routen ab", () => {
+    expect(parseHash("#/group/")).toEqual({ view: "home" });
+    expect(parseHash("#/control/")).toEqual({ view: "home" });
+  });
+
+  it("sanitiziert optionale control/top Route-Parameter fail-closed", () => {
+    const route = parseHash("#/search?control=%00%09CTRL-1&top=%20%20");
+    expect(route.view).toBe("search");
+    if (route.view === "search") {
+      expect(route.controlId).toBe("CTRL-1");
+      expect(route.controlTopGroupId).toBeNull();
+    }
+  });
+});
+
+describe("build hash helpers", () => {
+  it("kodiert Group- und Control-IDs fuer Hash-Routen", () => {
+    expect(buildGroupHash("OPS 1")).toBe("#/group/OPS%201");
+    expect(buildControlHash("APP-1.2", "APP ROOT")).toBe("#/control/APP-1.2?top=APP+ROOT");
+  });
+
+  it("baut Search-Hash inkl. Facetten und Detailkontext", () => {
+    const filters = defaultFilters();
+    filters.topGroupId = ["APP"];
+    filters.tags = ["netzwerk", "haertung"];
+    const hash = buildSearchHash("  Härtung  ", "title-desc", filters, "APP.1", "APP");
+
+    expect(hash).toContain("#/search?");
+    expect(hash).toContain("q=H%C3%A4rtung");
+    expect(hash).toContain("sort=title-desc");
+    expect(hash).toContain("tg=APP");
+    expect(hash).toContain("tag=netzwerk");
+    expect(hash).toContain("tag=haertung");
+    expect(hash).toContain("control=APP.1");
+    expect(hash).toContain("top=APP");
+  });
+
+  it("laesst leere Querys und Default-Sortierung weg", () => {
+    const hash = buildSearchHash("   ", "relevance", defaultFilters());
+    expect(hash).toBe("#/search");
+  });
+
+  it("unterstuetzt parse/build Roundtrip fuer Search-Routen", () => {
+    const filters = defaultFilters();
+    filters.groupId = ["OPS.1"];
+    filters.secLevel = ["hoch"];
+    filters.relationTypes = ["required"];
+    const hash = buildSearchHash("Kontrolle", "id-asc", filters, "OPS.1.2", "OPS");
+
+    const route = parseHash(hash);
+    expect(route.view).toBe("search");
+    if (route.view === "search") {
+      expect(route.query).toBe("Kontrolle");
+      expect(route.sort).toBe("id-asc");
+      expect(route.filters.groupId).toEqual(["OPS.1"]);
+      expect(route.filters.secLevel).toEqual(["hoch"]);
+      expect(route.filters.relationTypes).toEqual(["required"]);
+      expect(route.controlId).toBe("OPS.1.2");
+      expect(route.controlTopGroupId).toBe("OPS");
     }
   });
 });

--- a/src/lib/searchClient.test.ts
+++ b/src/lib/searchClient.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchClient } from "./searchClient";
+import { defaultFilters } from "./routing";
+import type { SearchResponse } from "../types";
+
+type WorkerEventType = "message" | "error" | "messageerror";
+
+class MockWorker {
+  static instances: MockWorker[] = [];
+
+  messages: Array<{ type: string; requestId: string; payload?: unknown }> = [];
+  terminated = false;
+
+  private listeners: Record<WorkerEventType, Array<(event: any) => void>> = {
+    message: [],
+    error: [],
+    messageerror: []
+  };
+
+  constructor(_scriptUrl: URL, _options?: WorkerOptions) {
+    MockWorker.instances.push(this);
+  }
+
+  addEventListener(type: WorkerEventType, listener: (event: any) => void) {
+    this.listeners[type].push(listener);
+  }
+
+  removeEventListener(type: WorkerEventType, listener: (event: any) => void) {
+    this.listeners[type] = this.listeners[type].filter((current) => current !== listener);
+  }
+
+  postMessage(message: { type: string; requestId: string; payload?: unknown }) {
+    this.messages.push(message);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  emitResponse(data: { requestId: string; ok: boolean; data?: unknown; error?: string }) {
+    for (const listener of this.listeners.message) {
+      listener({
+        data: {
+          type: "response",
+          ...data
+        }
+      });
+    }
+  }
+
+  emitMessageError() {
+    for (const listener of this.listeners.messageerror) {
+      listener({});
+    }
+  }
+
+  emitError(message: string) {
+    for (const listener of this.listeners.error) {
+      listener({ message });
+    }
+  }
+}
+
+function createSearchResponse(total = 1): SearchResponse {
+  return {
+    total,
+    items: [
+      {
+        id: `APP.${total}`,
+        title: "Test Control",
+        score: 1,
+        topGroupId: "APP",
+        groupId: "APP.1",
+        class: null,
+        secLevel: "hoch",
+        effortLevel: "2",
+        modalverbs: ["SOLL"],
+        targetObjects: [],
+        tags: ["netzwerk"],
+        snippet: "Test Control",
+        breadcrumbs: ["APP", "APP.1"]
+      }
+    ],
+    facets: {
+      topGroupId: [{ value: "APP", count: total }],
+      secLevel: [{ value: "hoch", count: total }],
+      effortLevel: [{ value: "2", count: total }],
+      class: [],
+      modalverbs: [{ value: "SOLL", count: total }],
+      targetObjects: [],
+      tags: [{ value: "netzwerk", count: total }],
+      relationTypes: []
+    },
+    elapsedMs: 4
+  };
+}
+
+function getWorkerInstance(): MockWorker {
+  const instance = MockWorker.instances[0];
+  if (!instance) {
+    throw new Error("MockWorker instance missing.");
+  }
+  return instance;
+}
+
+const originalWindow = globalThis.window;
+const originalWorker = globalThis.Worker;
+
+beforeEach(() => {
+  MockWorker.instances = [];
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    writable: true,
+    value: globalThis
+  });
+  Object.defineProperty(globalThis, "Worker", {
+    configurable: true,
+    writable: true,
+    value: MockWorker
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+  } else {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      writable: true,
+      value: originalWindow
+    });
+  }
+  if (originalWorker === undefined) {
+    Reflect.deleteProperty(globalThis, "Worker");
+  } else {
+    Object.defineProperty(globalThis, "Worker", {
+      configurable: true,
+      writable: true,
+      value: originalWorker
+    });
+  }
+});
+
+describe("SearchClient", () => {
+  it("resolves successful search responses from worker messages", async () => {
+    const client = new SearchClient();
+    const promise = client.search({
+      text: "APP",
+      sort: "relevance",
+      filters: defaultFilters()
+    });
+
+    const worker = getWorkerInstance();
+    const searchMessage = worker.messages.find((message) => message.type === "search");
+    expect(searchMessage).toBeDefined();
+    if (!searchMessage) {
+      throw new Error("Expected search message to be sent.");
+    }
+
+    const payload = createSearchResponse(1);
+    worker.emitResponse({
+      requestId: searchMessage.requestId,
+      ok: true,
+      data: payload
+    });
+
+    await expect(promise).resolves.toEqual(payload);
+    client.destroy();
+  });
+
+  it("cancels the previous search when a new search starts", async () => {
+    const client = new SearchClient();
+    const firstPromise = client
+      .search({
+        text: "erste suche",
+        sort: "relevance",
+        filters: defaultFilters()
+      })
+      .catch((error) => error as Error);
+
+    const worker = getWorkerInstance();
+    const firstSearchMessage = worker.messages.find((message) => message.type === "search");
+    expect(firstSearchMessage).toBeDefined();
+    if (!firstSearchMessage) {
+      throw new Error("Expected first search message.");
+    }
+
+    const secondPromise = client.search({
+      text: "zweite suche",
+      sort: "id-asc",
+      filters: defaultFilters()
+    });
+
+    const cancelMessage = worker.messages.find((message) => message.type === "cancel");
+    expect(cancelMessage).toEqual({
+      type: "cancel",
+      requestId: firstSearchMessage.requestId
+    });
+
+    const firstError = await firstPromise;
+    expect(firstError).toBeInstanceOf(Error);
+    if (!(firstError instanceof Error)) {
+      throw new Error("Expected cancelled search to reject with Error.");
+    }
+    expect(firstError.message).toBe("Vorherige Anfrage wurde abgebrochen.");
+
+    const searchMessages = worker.messages.filter((message) => message.type === "search");
+    const secondSearchMessage = searchMessages[1];
+    expect(secondSearchMessage).toBeDefined();
+    if (!secondSearchMessage) {
+      throw new Error("Expected second search message.");
+    }
+
+    const secondPayload = createSearchResponse(2);
+    worker.emitResponse({
+      requestId: secondSearchMessage.requestId,
+      ok: true,
+      data: secondPayload
+    });
+
+    await expect(secondPromise).resolves.toEqual(secondPayload);
+    client.destroy();
+  });
+
+  it("rejects pending requests on worker messageerror", async () => {
+    const client = new SearchClient();
+    const promise = client.getControl("APP.1", "APP");
+    const worker = getWorkerInstance();
+    worker.emitMessageError();
+
+    await expect(promise).rejects.toThrow("Ungueltige Worker-Nachricht erhalten.");
+    client.destroy();
+  });
+
+  it("rejects pending requests on worker runtime error", async () => {
+    const client = new SearchClient();
+    const promise = client.init("./data/catalog-index.json", "./data/details");
+    const worker = getWorkerInstance();
+    worker.emitError("worker crashed");
+
+    await expect(promise).rejects.toThrow("worker crashed");
+    client.destroy();
+  });
+
+  it("rejects timed out worker requests", async () => {
+    vi.useFakeTimers();
+
+    const client = new SearchClient();
+    const promise = client.getNeighborhood("APP.1", 1).catch((error) => error as Error);
+    await vi.advanceTimersByTimeAsync(15000);
+
+    const timeoutError = await promise;
+    expect(timeoutError).toBeInstanceOf(Error);
+    if (!(timeoutError instanceof Error)) {
+      throw new Error("Expected timeout to reject with Error.");
+    }
+    expect(timeoutError.message).toBe("Worker-Timeout bei 'get-neighborhood' nach 15000ms.");
+    client.destroy();
+  });
+
+  it("rejects pending requests and terminates worker on destroy", async () => {
+    const client = new SearchClient();
+    const promise = client.search({
+      text: "offen",
+      sort: "relevance",
+      filters: defaultFilters()
+    });
+
+    const worker = getWorkerInstance();
+    client.destroy();
+
+    await expect(promise).rejects.toThrow("Worker wurde beendet.");
+    expect(worker.terminated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add SearchClient lifecycle integration tests for cancel, timeout, error, messageerror, and destroy paths
- expand routing hardening tests for invalid params, sanitization, hash builder behavior, and parse/build roundtrip
- add component-near tests for ResultList and GroupPage covering loading, error, empty, select-all labels, and pagination states
- document implemented Phase B measures in docs/coverage-phase-b-implementation.md

## Validation
- npm run test:unit:raw
- npm run test:unit