### PR TITLE
Phase C: Worker contracts, selective E2E hardening, and CI coverage gates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,11 +34,51 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Chromium for Playwright
-        run: npx playwright install --with-deps chromium
-
       - name: Run Dependency Audit Policy
         run: npm run audit:prod && npm run audit:dev
 
-      - name: Run QA checks
-        run: npm run qa
+      - name: Run Unit Coverage Gate
+        run: npm run test:unit:coverage
+
+      - name: Run Release Hygiene Check
+        run: npm run check:release-hygiene
+
+      - name: Upload Unit Coverage Artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-coverage
+          path: coverage/unit
+          if-no-files-found: error
+
+  browser-qa:
+    needs: qa
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      VITE_OPERATOR_NAME: Max Mustermann
+      VITE_OPERATOR_ADDRESS_LINE1: Musterstrasse 1
+      VITE_OPERATOR_ADDRESS_LINE2: 10115 Berlin
+      VITE_OPERATOR_EMAIL: max.mustermann@example.invalid
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium for Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Build app
+        run: npm run build
+
+      - name: Run Browser QA checks
+        run: npm run qa:browser

--- a/docs/coverage-phase-c-implementation.md
+++ b/docs/coverage-phase-c-implementation.md
@@ -1,0 +1,130 @@
+# Coverage Phase C Implementation (2026-03-09)
+
+## 1. Kurzueberblick der umgesetzten Phase-C-Massnahmen
+
+Phase C wurde auf die risikostaerksten Restluecken fokussiert umgesetzt:
+
+- Worker-Vertragsgrenze mit dedizierten Contract-Tests abgesichert (`src/workers/searchWorker.test.ts`)
+- Fehler-/Resilienzpfade am Worker-Client erweitert (`src/lib/searchClient.test.ts`)
+- Selektive E2E-Haertung fuer Deep-Link, Route-Fallback und realen CSV-Exportfluss (`tests/core-flows.spec.ts`)
+- CI-Gates fuer Unit-Coverage + getrennte Browser-QA in `quality.yml` eingefuehrt
+- Coverage-Messung inkl. Mindestschwellen im Vitest-Setup aktiviert
+
+Es wurden keine grossflaechigen Produktumbauten durchgefuehrt.
+
+## 2. Welche Worker-/Systemgrenzen abgesichert wurden
+
+### Worker-Schnittstelle (`searchWorker`)
+
+- Message-Envelope-Haertung: malformed inbound messages werden ignoriert.
+- Positive Vertragsfaelle: `init` und `search` liefern korrekte `response`-Nachrichten.
+- Negative Vertragsfaelle:
+  - unbekannter Request-Typ liefert definierte Fehlerantwort
+  - `get-control` mit nicht aufloesbarer ID liefert fail-closed Fehler
+  - `cancel` fuehrt bei laufender Suche zu sauberem Abbruch (`Anfrage wurde abgebrochen.`)
+- Graph-Grenze:
+  - `get-neighborhood` clamps hops robust auf erlaubte Werte
+  - Relationen werden ueber Detail-Chunk-Grenze aufgeloest
+
+### Worker-Client-Grenze (`searchClient`)
+
+- Explizite Worker-Fehlerantwort (`ok: false`) wird deterministisch als Error propagiert.
+- Nicht-vertragskonforme Worker-Messages (kein `type: response`) werden ignoriert.
+- Synchronous `postMessage`-Fehlerpfad ist abgesichert.
+
+## 3. Welche selektiven E2E-Flows ergaenzt wurden
+
+- Direkter Control-Deep-Link aus realem Suchkontext in `#/control/:id?top=:topGroupId`
+- Ungueltige Control-Route (`#/control/%E0%A4%A`) mit robustem Fallback auf Startansicht
+- CSV-Export aus realistischer Suchauswahl inkl. Erfolgspfad und UI-Ruecksetzung
+
+Diese E2E-Erweiterungen wurden bewusst klein gehalten und decken benoetigte Systemgrenzen ab, die Unit-/Integrationstests nicht gleichwertig pruefen.
+
+## 4. Welche CI-/Gate-Anpassungen vorgenommen wurden
+
+### Coverage/Gates
+
+- `@vitest/coverage-v8` als Dev-Dependency hinzugefuegt.
+- Neues Skript: `test:unit:coverage`.
+- `vitest.config.ts` um Coverage-Konfiguration erweitert:
+  - Reports: `text`, `text-summary`, `json-summary`, `lcov`
+  - Verzeichnis: `coverage/unit`
+  - Mindestschwellen:
+    - `lines: 30`
+    - `functions: 34`
+    - `branches: 24`
+    - `statements: 30`
+
+### CI-Workflow
+
+- `.github/workflows/quality.yml` in zwei Jobs getrennt:
+  - `qa` (schneller PR-Gate):
+    - Dependency-Audit
+    - Unit-Coverage-Gate
+    - Release-Hygiene
+    - Upload des Coverage-Artefakts
+  - `browser-qa` (schwerer Lauf, nach `qa`):
+    - Build
+    - Lighthouse + Playwright/Axe via `qa:browser`
+
+### Skriptstruktur
+
+- Neues Skript: `qa:browser`
+- `qa` auf `build + unit + hygiene + qa:browser` umgestellt (funktionale Entsprechung erhalten)
+
+## 5. Welche Refactorings durchgefuehrt wurden und warum
+
+- Keine produktiven Architektur-Refactorings.
+- Nur testnahe/CI-nahe Anpassungen:
+  - Worker-Testharness ueber `self`-Mock fuer echte Message-Grenztests
+  - kleine Skriptentkopplung (`qa:browser`) zur sauberen Gate-Trennung
+
+## 6. Welche Risiken weiterhin offen bleiben
+
+- `src/App.tsx` als zentrale Orchestrierung bleibt weiterhin ohne dedizierte domnahe Integrationstests.
+- Service-Worker-Laufzeitpfade in `src/main.tsx` sind weiterhin nicht direkt getestet.
+- Build-/Sync-Skripte (`scripts/build-catalog.mjs`, `scripts/sync-bsi-catalogs.mjs`) haben weiterhin keine eigenen Integrationstests.
+
+## 7. Welche Themen bewusst nicht umgesetzt wurden
+
+- Keine breite E2E-Ausweitung (nur selektive High-Risk-Flows)
+- Keine Browser-Matrix-Erweiterung
+- Keine visuellen Regressionstests
+- Kein grosser Worker- oder App-Refactor fuer maximale Coverage
+- Keine Tests fuer generierte Artefakte um ihrer selbst willen
+
+## 8. Welche Test-/QA-Kommandos ausgefuehrt wurden und mit welchem Ergebnis
+
+- `npm install`
+  - erfolgreich (Lockfile aktualisiert)
+
+- `npm run test:unit:raw`
+  - erfolgreich
+  - 22 Testdateien, 95 Tests, alle gruen
+
+- `npm run test:unit:coverage`
+  - erfolgreich
+  - Coverage-Schwellen eingehalten
+  - Summary:
+    - Statements: `42.17%`
+    - Branches: `37.31%`
+    - Functions: `39.95%`
+    - Lines: `42.35%`
+
+- `npm run build`
+  - erfolgreich
+
+- `npm run check:release-hygiene`
+  - erfolgreich
+
+- `npx start-server-and-test "npm run preview" http://127.0.0.1:4173 "npx playwright test tests/core-flows.spec.ts --config=playwright.a11y.config.ts"`
+  - erfolgreich
+  - 14/14 Tests bestanden
+
+- `npx start-server-and-test "npm run preview" http://127.0.0.1:4173 "npm run qa:a11y"`
+  - erfolgreich
+  - 18/18 Tests bestanden
+
+- `npm run qa:browser`
+  - erfolgreich (ausserhalb Sandbox ausgefuehrt)
+  - Lighthouse + Playwright/Axe bestanden

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,18 @@
   - URL-Sicherheit (`urlSafety`)
   - Routing-Härtung (`routing`)
   - Datenschema-Validierung inkl. Budgetgrenzen (`dataSchemas`)
+  - Worker-Vertragsgrenze (`searchWorker`, `searchClient`)
   - statisches Rendering zentraler UI-Komponenten
+
+### Coverage-Gates
+
+- Unit-Coverage wird über `vitest --coverage` (Provider `v8`) gemessen.
+- Berichte liegen unter `coverage/unit`.
+- Aktive Mindestschwellen:
+  - `lines: 30`
+  - `functions: 34`
+  - `branches: 24`
+  - `statements: 30`
 
 ### 2) End-to-End-Tests (Playwright)
 
@@ -39,6 +50,7 @@
 
 ```bash
 npm run test:unit
+npm run test:unit:coverage
 npm run qa
 ```
 
@@ -46,11 +58,9 @@ Hinweis: `public/data/**` und `public/sw.js` sind nicht versioniert und werden i
 
 ### CI
 
-Workflow `.github/workflows/quality.yml` führt aus:
-1. Install
-2. Playwright Browser Install
-3. Dependency-Audit
-4. `npm run qa`
+Workflow `.github/workflows/quality.yml` führt getrennte Gates aus:
+1. `qa` (schnell, PR-pflichtig): Audit, Unit-Coverage-Gate, Release-Hygiene
+2. `browser-qa` (schwerer): Build, Lighthouse, Playwright/Axe
 
 ## Nachgewiesene lokale Läufe (2026-03-06)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.0",
+        "@vitest/coverage-v8": "^4.0.18",
         "start-server-and-test": "^2.1.5",
         "typescript": "^5.9.3",
         "vite": "^7.1.4",
@@ -323,6 +324,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1774,6 +1785,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -2008,6 +2050,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3701,6 +3762,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3969,6 +4037,97 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/joi": {
@@ -4450,6 +4609,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "preview": "vite preview --strictPort --host 127.0.0.1 --port 4173",
     "test:unit:raw": "vitest run",
     "test:unit": "npm run build && npm run test:unit:raw",
+    "test:unit:coverage": "npm run build && vitest run --coverage",
     "check:release-hygiene": "npm run clean:release-artifacts && node scripts/check-release-hygiene.mjs",
     "audit:prod": "npm audit --omit=dev --audit-level=high",
     "audit:dev": "node scripts/audit-dev-policy.mjs",
     "qa:lighthouse": "lhci autorun --config=./lighthouserc.json",
     "qa:a11y": "playwright test --config=playwright.a11y.config.ts",
-    "qa": "npm run build && npm run test:unit:raw && npm run check:release-hygiene && start-server-and-test preview http://127.0.0.1:4173 \"npm run qa:lighthouse && npm run qa:a11y\""
+    "qa:browser": "start-server-and-test preview http://127.0.0.1:4173 \"npm run qa:lighthouse && npm run qa:a11y\"",
+    "qa": "npm run build && npm run test:unit:raw && npm run check:release-hygiene && npm run qa:browser"
   },
   "dependencies": {
     "react": "^19.2.4",
@@ -32,6 +34,7 @@
     "@axe-core/playwright": "^4.11.1",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.58.2",
+    "@vitest/coverage-v8": "^4.0.18",
     "@types/node": "^25.3.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/lib/searchClient.test.ts
+++ b/src/lib/searchClient.test.ts
@@ -10,6 +10,7 @@ class MockWorker {
 
   messages: Array<{ type: string; requestId: string; payload?: unknown }> = [];
   terminated = false;
+  throwOnPostMessage: Error | null = null;
 
   private listeners: Record<WorkerEventType, Array<(event: any) => void>> = {
     message: [],
@@ -30,6 +31,9 @@ class MockWorker {
   }
 
   postMessage(message: { type: string; requestId: string; payload?: unknown }) {
+    if (this.throwOnPostMessage) {
+      throw this.throwOnPostMessage;
+    }
     this.messages.push(message);
   }
 
@@ -45,6 +49,12 @@ class MockWorker {
           ...data
         }
       });
+    }
+  }
+
+  emitRawMessage(data: unknown) {
+    for (const listener of this.listeners.message) {
+      listener({ data });
     }
   }
 
@@ -243,6 +253,55 @@ describe("SearchClient", () => {
     client.destroy();
   });
 
+  it("rejects requests when worker returns an explicit error response", async () => {
+    const client = new SearchClient();
+    const promise = client.getControl("APP.1", "APP");
+    const worker = getWorkerInstance();
+    const request = worker.messages.find((message) => message.type === "get-control");
+    expect(request).toBeDefined();
+    if (!request) {
+      throw new Error("Expected get-control request.");
+    }
+
+    worker.emitResponse({
+      requestId: request.requestId,
+      ok: false,
+      error: "Control konnte nicht geladen werden."
+    });
+
+    await expect(promise).rejects.toThrow("Control konnte nicht geladen werden.");
+    client.destroy();
+  });
+
+  it("ignores non-response worker messages and resolves on the matching response", async () => {
+    const client = new SearchClient();
+    const promise = client.search({
+      text: "APP",
+      sort: "relevance",
+      filters: defaultFilters()
+    });
+    const worker = getWorkerInstance();
+    const request = worker.messages.find((message) => message.type === "search");
+    expect(request).toBeDefined();
+    if (!request) {
+      throw new Error("Expected search request.");
+    }
+
+    worker.emitRawMessage({
+      type: "progress",
+      requestId: request.requestId,
+      percent: 50
+    });
+    worker.emitResponse({
+      requestId: request.requestId,
+      ok: true,
+      data: createSearchResponse(3)
+    });
+
+    await expect(promise).resolves.toEqual(createSearchResponse(3));
+    client.destroy();
+  });
+
   it("rejects timed out worker requests", async () => {
     vi.useFakeTimers();
 
@@ -256,6 +315,22 @@ describe("SearchClient", () => {
       throw new Error("Expected timeout to reject with Error.");
     }
     expect(timeoutError.message).toBe("Worker-Timeout bei 'get-neighborhood' nach 15000ms.");
+    client.destroy();
+  });
+
+  it("rejects when worker postMessage throws synchronously", async () => {
+    const client = new SearchClient();
+    const worker = getWorkerInstance();
+    worker.throwOnPostMessage = new Error("post failed");
+
+    await expect(
+      client.search({
+        text: "APP",
+        sort: "relevance",
+        filters: defaultFilters()
+      })
+    ).rejects.toThrow("post failed");
+
     client.destroy();
   });
 

--- a/src/workers/searchWorker.test.ts
+++ b/src/workers/searchWorker.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ControlDetail, SearchDoc } from "../types";
+import { defaultFilters } from "../lib/routing";
+
+const fetchJsonWithValidationMock = vi.fn();
+
+vi.mock("../lib/fetchJsonSafe", () => ({
+  fetchJsonWithValidation: fetchJsonWithValidationMock
+}));
+
+interface WorkerMessageRequest {
+  type: string;
+  requestId: string;
+  payload?: unknown;
+}
+
+interface WorkerMessageResponse {
+  type: "response";
+  requestId: string;
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+class MockWorkerScope {
+  private onMessage: ((event: MessageEvent<WorkerMessageRequest>) => Promise<void> | void) | null = null;
+  responses: WorkerMessageResponse[] = [];
+
+  addEventListener(type: string, handler: (event: MessageEvent<WorkerMessageRequest>) => Promise<void> | void) {
+    if (type === "message") {
+      this.onMessage = handler;
+    }
+  }
+
+  postMessage(message: WorkerMessageResponse) {
+    this.responses.push(message);
+  }
+
+  async dispatch(data: Partial<WorkerMessageRequest>) {
+    if (!this.onMessage) {
+      throw new Error("Worker message listener wurde nicht registriert.");
+    }
+    await this.onMessage({ data: data as WorkerMessageRequest } as MessageEvent<WorkerMessageRequest>);
+  }
+}
+
+function createDoc(id: string, overrides: Partial<SearchDoc> = {}): SearchDoc {
+  const topGroupId = overrides.topGroupId ?? "APP";
+  return {
+    docId: `doc-${id}`,
+    entityType: "control",
+    id,
+    title: `Control ${id}`,
+    class: null,
+    topGroupId,
+    parentGroupId: null,
+    parentControlId: null,
+    breadcrumbs: [topGroupId, id],
+    groupPathIds: [topGroupId],
+    groupPathTitles: [topGroupId],
+    statementText: `Statement fuer ${id}`,
+    guidanceText: `Guidance fuer ${id}`,
+    paramsText: "",
+    propsText: "",
+    facets: {
+      topGroupId,
+      groupId: `${topGroupId}.1`,
+      secLevel: "hoch",
+      effortLevel: "2",
+      class: null,
+      tags: ["netzwerk"],
+      modalverbs: ["SOLL"],
+      targetObjects: ["SYS.1"],
+      relationTypes: ["required"],
+      hasRelations: false
+    },
+    ...overrides
+  };
+}
+
+function createDetail(
+  id: string,
+  topGroupId: string,
+  overrides: Partial<ControlDetail> = {}
+): ControlDetail {
+  return {
+    id,
+    title: `Control ${id}`,
+    class: null,
+    topGroupId,
+    parentGroupId: null,
+    parentControlId: null,
+    controlDepth: 1,
+    groupPathIds: [topGroupId],
+    groupPathTitles: [topGroupId],
+    controlPathIds: [id],
+    controlPathTitles: [id],
+    pathIds: [topGroupId, id],
+    breadcrumbs: [topGroupId, id],
+    statementText: `Statement fuer ${id}`,
+    guidanceText: "",
+    props: [],
+    propsMap: {},
+    params: [],
+    parts: [],
+    tags: ["netzwerk"],
+    modalverbs: ["SOLL"],
+    targetObjects: ["SYS.1"],
+    secLevel: "hoch",
+    effortLevel: "2",
+    links: [],
+    relationsOutgoing: [],
+    relationsIncoming: [],
+    ...overrides
+  };
+}
+
+function findResponse(scope: MockWorkerScope, requestId: string): WorkerMessageResponse {
+  const response = scope.responses.find((entry) => entry.requestId === requestId);
+  if (!response) {
+    throw new Error(`Antwort fuer ${requestId} fehlt.`);
+  }
+  return response;
+}
+
+async function loadWorker(scope: MockWorkerScope) {
+  Object.defineProperty(globalThis, "self", {
+    configurable: true,
+    writable: true,
+    value: scope
+  });
+  await import("./searchWorker");
+}
+
+const originalSelf = (globalThis as { self?: unknown }).self;
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (originalSelf === undefined) {
+    Reflect.deleteProperty(globalThis as Record<string, unknown>, "self");
+  } else {
+    Object.defineProperty(globalThis, "self", {
+      configurable: true,
+      writable: true,
+      value: originalSelf
+    });
+  }
+});
+
+describe("searchWorker contract", () => {
+  it("ignores malformed inbound messages without request envelope", async () => {
+    const scope = new MockWorkerScope();
+    await loadWorker(scope);
+
+    await scope.dispatch({ payload: { any: true } });
+    expect(scope.responses).toHaveLength(0);
+  });
+
+  it("returns init/search responses for valid worker message contracts", async () => {
+    const docs = [createDoc("APP.1"), createDoc("APP.2")];
+    fetchJsonWithValidationMock.mockImplementation(async ({ label }: { label: string }) => {
+      if (label === "Indexdaten") {
+        return {
+          stats: {
+            topGroupCount: 1,
+            groupCount: 2,
+            controlCount: 2,
+            relationCount: 0,
+            controlsWithRelations: 0
+          },
+          facetOptions: {
+            topGroupId: ["APP"],
+            secLevel: ["hoch"],
+            effortLevel: ["2"],
+            class: [],
+            modalverbs: ["SOLL"],
+            targetObjects: ["SYS.1"],
+            tags: ["netzwerk"],
+            relationTypes: []
+          },
+          docs
+        };
+      }
+      throw new Error(`Unerwartetes Label: ${label}`);
+    });
+
+    const scope = new MockWorkerScope();
+    await loadWorker(scope);
+
+    await scope.dispatch({
+      type: "init",
+      requestId: "init-1",
+      payload: {
+        indexUrl: "/data/catalog-index.json",
+        detailBasePath: "/data/details"
+      }
+    });
+    await scope.dispatch({
+      type: "search",
+      requestId: "search-1",
+      payload: {
+        text: "APP.1",
+        sort: "relevance",
+        filters: defaultFilters(),
+        limit: 10,
+        offset: 0
+      }
+    });
+
+    const initResponse = findResponse(scope, "init-1");
+    expect(initResponse.ok).toBe(true);
+    expect(initResponse.data).toMatchObject({
+      stats: {
+        controlCount: 2
+      }
+    });
+
+    const searchResponse = findResponse(scope, "search-1");
+    expect(searchResponse.ok).toBe(true);
+    expect(searchResponse.data).toMatchObject({
+      total: 1,
+      items: [{ id: "APP.1" }]
+    });
+  });
+
+  it("returns a protocol error response for unknown request types", async () => {
+    const scope = new MockWorkerScope();
+    await loadWorker(scope);
+
+    await scope.dispatch({
+      type: "unknown",
+      requestId: "req-unknown",
+      payload: {}
+    });
+
+    const response = findResponse(scope, "req-unknown");
+    expect(response.ok).toBe(false);
+    expect(response.error).toContain("Unbekannter Request-Typ");
+  });
+
+  it("returns an error for unresolved control IDs", async () => {
+    fetchJsonWithValidationMock.mockImplementation(async ({ label, url }: { label: string; url: string }) => {
+      if (label === "Indexdaten") {
+        return {
+          stats: {
+            topGroupCount: 1,
+            groupCount: 1,
+            controlCount: 1,
+            relationCount: 0,
+            controlsWithRelations: 0
+          },
+          facetOptions: {
+            topGroupId: ["APP"],
+            secLevel: [],
+            effortLevel: [],
+            class: [],
+            modalverbs: [],
+            targetObjects: [],
+            tags: [],
+            relationTypes: []
+          },
+          docs: [createDoc("APP.1")]
+        };
+      }
+      if (label === "Detail-Chunk fuer APP" && url.endsWith("/APP.json")) {
+        return { controls: {} };
+      }
+      throw new Error(`Unerwartete Anfrage: ${label} (${url})`);
+    });
+
+    const scope = new MockWorkerScope();
+    await loadWorker(scope);
+
+    await scope.dispatch({
+      type: "init",
+      requestId: "init-for-control",
+      payload: {
+        indexUrl: "/data/catalog-index.json",
+        detailBasePath: "/data/details"
+      }
+    });
+    await scope.dispatch({
+      type: "get-control",
+      requestId: "control-missing",
+      payload: {
+        id: "APP.404",
+        topGroupId: "APP"
+      }
+    });
+
+    const response = findResponse(scope, "control-missing");
+    expect(response.ok).toBe(false);
+    expect(response.error).toContain("Control APP.404 wurde nicht gefunden.");
+  });
+
+  it("clamps neighborhood hops and returns graph payload with resolved relations", async () => {
+    const app1 = createDoc("APP.1");
+    const app2 = createDoc("APP.2");
+    fetchJsonWithValidationMock.mockImplementation(async ({ label, url }: { label: string; url: string }) => {
+      if (label === "Indexdaten") {
+        return {
+          stats: {
+            topGroupCount: 1,
+            groupCount: 1,
+            controlCount: 2,
+            relationCount: 1,
+            controlsWithRelations: 2
+          },
+          facetOptions: {
+            topGroupId: ["APP"],
+            secLevel: [],
+            effortLevel: [],
+            class: [],
+            modalverbs: [],
+            targetObjects: [],
+            tags: [],
+            relationTypes: ["required"]
+          },
+          docs: [app1, app2]
+        };
+      }
+      if (label === "Detail-Chunk fuer APP" && url.endsWith("/APP.json")) {
+        return {
+          controls: {
+            "APP.1": createDetail("APP.1", "APP", {
+              relationsOutgoing: [{ sourceControlId: "APP.1", targetControlId: "APP.2", relType: "required" }]
+            }),
+            "APP.2": createDetail("APP.2", "APP", {
+              relationsIncoming: [{ sourceControlId: "APP.1", targetControlId: "APP.2", relType: "required" }]
+            })
+          }
+        };
+      }
+      throw new Error(`Unerwartete Anfrage: ${label} (${url})`);
+    });
+
+    const scope = new MockWorkerScope();
+    await loadWorker(scope);
+
+    await scope.dispatch({
+      type: "init",
+      requestId: "init-for-graph",
+      payload: {
+        indexUrl: "/data/catalog-index.json",
+        detailBasePath: "/data/details"
+      }
+    });
+    await scope.dispatch({
+      type: "get-neighborhood",
+      requestId: "graph-1",
+      payload: {
+        id: "APP.1",
+        hops: 99
+      }
+    });
+
+    const response = findResponse(scope, "graph-1");
+    expect(response.ok).toBe(true);
+    expect(response.data).toMatchObject({
+      focusId: "APP.1",
+      hops: 1
+    });
+    expect((response.data as { nodes: Array<{ id: string }> }).nodes.map((node) => node.id)).toContain("APP.2");
+    expect((response.data as { edges: Array<{ relType: string }> }).edges[0]?.relType).toBe("required");
+  });
+
+  it("fails search requests with a cancellation error after cancel message", async () => {
+    const docs = Array.from({ length: 260 }, (_, index) => createDoc(`APP.${index + 1}`));
+    fetchJsonWithValidationMock.mockResolvedValue({
+      stats: {
+        topGroupCount: 1,
+        groupCount: 1,
+        controlCount: docs.length,
+        relationCount: 0,
+        controlsWithRelations: 0
+      },
+      facetOptions: {
+        topGroupId: ["APP"],
+        secLevel: [],
+        effortLevel: [],
+        class: [],
+        modalverbs: [],
+        targetObjects: [],
+        tags: [],
+        relationTypes: []
+      },
+      docs
+    });
+
+    const scope = new MockWorkerScope();
+    await loadWorker(scope);
+
+    await scope.dispatch({
+      type: "init",
+      requestId: "init-cancel",
+      payload: {
+        indexUrl: "/data/catalog-index.json",
+        detailBasePath: "/data/details"
+      }
+    });
+
+    const searchPromise = scope.dispatch({
+      type: "search",
+      requestId: "search-cancel",
+      payload: {
+        text: "",
+        sort: "relevance",
+        filters: defaultFilters(),
+        limit: 1200,
+        offset: 0
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await scope.dispatch({
+      type: "cancel",
+      requestId: "search-cancel"
+    });
+    await searchPromise;
+
+    const response = findResponse(scope, "search-cancel");
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe("Anfrage wurde abgebrochen.");
+  });
+});

--- a/tests/core-flows.spec.ts
+++ b/tests/core-flows.spec.ts
@@ -162,6 +162,32 @@ test.describe("Kernflows", () => {
     await expect(page).not.toHaveURL(/control=/);
   });
 
+  test("Direkter Control-Deep-Link oeffnet die Detailansicht stabil", async ({ page }) => {
+    await page.goto("/#/search?q=KONF");
+    await page.locator(".result-card").first().click();
+    await expect(page).toHaveURL(/control=/);
+
+    const currentUrl = new URL(page.url());
+    const hashQuery = currentUrl.hash.split("?")[1] ?? "";
+    const params = new URLSearchParams(hashQuery);
+    const controlId = params.get("control");
+    const topGroupId = params.get("top");
+
+    expect(controlId).toBeTruthy();
+    expect(topGroupId).toBeTruthy();
+    if (!controlId || !topGroupId) {
+      throw new Error("Control-Deep-Link konnte nicht aus der URL gelesen werden.");
+    }
+
+    await page.goto(`/#/control/${encodeURIComponent(controlId)}?top=${encodeURIComponent(topGroupId)}`);
+    await expect(page.locator(".detail-header h2 span").first()).toHaveText(controlId, { timeout: 15000 });
+  });
+
+  test("Ungueltige Control-Route faellt robust auf die Startansicht zurueck", async ({ page }) => {
+    await page.goto("/#/control/%E0%A4%A?top=GC");
+    await expect(page.getByRole("heading", { name: "Bereiche" })).toBeVisible({ timeout: 15000 });
+  });
+
   test("Graph-Knoten-Klick wechselt in den geklickten Control-Kontext", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto("/#/search?q=GC.2.1");
@@ -194,6 +220,18 @@ test.describe("Kernflows", () => {
     await page.getByRole("checkbox", { name: "Für CSV auswählen" }).first().check();
     await expect(page.getByRole("button", { name: "Export CSV (1)" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Export CSV (1)" })).toBeEnabled();
+  });
+
+  test("CSV Export laeuft aus dem Suchkontext erfolgreich durch", async ({ page }) => {
+    await page.goto("/#/search?q=KONF");
+    await page.getByRole("checkbox", { name: "Für CSV auswählen" }).first().check();
+
+    const exportButton = page.getByRole("button", { name: "Export CSV (1)" });
+    await expect(exportButton).toBeVisible();
+    await exportButton.click();
+
+    await expect(page.getByText(/CSV erfolgreich exportiert/)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("button", { name: /Export CSV/ })).toHaveCount(0);
   });
 
   test("Mobile: kein Overflow-Trigger, CSV-Export bleibt über Header erreichbar", async ({ page }) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,26 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
-    environment: "node"
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary", "json-summary", "lcov"],
+      reportsDirectory: "coverage/unit",
+      include: ["src/**/*.{ts,tsx,js}"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src/**/*.d.ts",
+        "src/vite-env.d.ts",
+        "src/types.ts",
+        "src/styles.css"
+      ],
+      thresholds: {
+        lines: 30,
+        functions: 34,
+        branches: 24,
+        statements: 30
+      }
+    }
   }
 });


### PR DESCRIPTION
## Ziel
Phase-C-Restluecken an den risikoreichsten Systemgrenzen schliessen (Worker-Vertrag, Fehlerpfade, selektive E2E-Haertung, robuste CI-Gates).

## Umgesetzt
- Neue Worker-Contract-Tests in src/workers/searchWorker.test.ts (init/search/get-control/get-neighborhood/cancel/invalid requests).
- Erweiterte Fehlerpfad-Tests fuer src/lib/searchClient.test.ts (error-responses, invalid messages, postMessage-Fehler).
- Selektive E2E-Erweiterungen in tests/core-flows.spec.ts:
  - direkter Control-Deep-Link
  - ungueltige Control-Route mit Fallback
  - CSV-Export-Erfolgspfad aus realistischem Suchkontext
- Coverage/Gates:
  - @vitest/coverage-v8 + test:unit:coverage
  - Coverage-Thresholds in vitest.config.ts
  - quality.yml gesplittet in schnellen qa-Gate und separaten browser-qa-Job
  - Upload des Coverage-Artefakts
- Dokumentation aktualisiert:
  - docs/testing.md
  - docs/coverage-phase-c-implementation.md

## Validierung
- npm run test:unit:raw
- npm run test:unit:coverage
- npm run build
- npm run check:release-hygiene
- npx start-server-and-test "npm run preview" http://127.0.0.1:4173 "npx playwright test tests/core-flows.spec.ts --config=playwright.a11y.config.ts"
- npx start-server-and-test "npm run preview" http://127.0.0.1:4173 "npm run qa:a11y"
- npm run qa:browser

## Hinweise
- Keine grossflaechigen Produktrefactorings; nur test-/gate-orientierte, eng begrenzte Aenderungen.
- Bereits vorhandene untracked Datei docs/qa-coverage-gap-analysis.md wurde bewusst nicht veraendert.
