### PR TITLE
chore: finalize integrated QA/coverage end state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+coverage
 .DS_Store
 *.tsbuildinfo
 .lighthouseci

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ npm run sync:bsi
 - [Schnittstellen](docs/api-and-interfaces.md)
 - [Security Review](docs/security-review.md)
 - [Teststrategie](docs/testing.md)
+- [QA/Coverage Finalisierung](docs/qa-coverage-finalization.md)
+- [QA/Coverage Maintenance Summary](docs/qa-coverage-maintenance-summary.md)
 - [Developer Onboarding](docs/developer-onboarding.md)
 - [ADR-Zusammenfassung](docs/adr-summary.md)
 - [Offene Punkte / Gaps](docs/open-issues-and-gaps.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ Aufgabe:
 
 - TypeScript `strict` ist `false`.
 - Keine dedizierte Linting-/Formatting-Pipeline im `package.json`.
-- Keine Coverage-Messung konfiguriert.
+- Unit-Coverage ist als Vitest-Gate konfiguriert (`vitest --coverage` via `test:unit:coverage`) mit globalen Mindestschwellen.
 - GitHub Pages bietet nur eingeschränkte, nicht repository-lokale Steuerung von Response-Headern.
 - Keine serverseitigen APIs oder Datenbanken.
 - Keine Authentifizierung/Autorisierung implementiert.

--- a/docs/coverage-phase-a-implementation.md
+++ b/docs/coverage-phase-a-implementation.md
@@ -1,5 +1,7 @@
 # Coverage Phase A Implementation (2026-03-09)
 
+> Historisches Umsetzungsprotokoll. Maßgeblicher Endstand: `docs/qa-coverage-finalization.md`.
+
 ## 1. Kurzueberblick der umgesetzten Phase-A-Massnahmen
 
 Auf Basis der vorhandenen Analyse (`docs/qa-coverage-gap-analysis.md`) wurden die priorisierten, schnell umsetzbaren Unit-Tests fuer kritische pure Logik und fail-closed Fehlerpfade umgesetzt. Fokus war auf:

--- a/docs/coverage-phase-b-implementation.md
+++ b/docs/coverage-phase-b-implementation.md
@@ -1,5 +1,7 @@
 # Coverage Phase B Implementation (2026-03-09)
 
+> Historisches Umsetzungsprotokoll. Maßgeblicher Endstand: `docs/qa-coverage-finalization.md`.
+
 ## 1. Kurzueberblick der umgesetzten Phase-B-Massnahmen
 
 Phase B erweitert die Testtiefe gezielt in drei Bereichen:

--- a/docs/coverage-phase-c-implementation.md
+++ b/docs/coverage-phase-c-implementation.md
@@ -1,5 +1,7 @@
 # Coverage Phase C Implementation (2026-03-09)
 
+> Historisches Umsetzungsprotokoll. Maßgeblicher Endstand: `docs/qa-coverage-finalization.md`.
+
 ## 1. Kurzueberblick der umgesetzten Phase-C-Massnahmen
 
 Phase C wurde auf die risikostaerksten Restluecken fokussiert umgesetzt:

--- a/docs/open-issues-and-gaps.md
+++ b/docs/open-issues-and-gaps.md
@@ -13,9 +13,9 @@
 
 ## Qualitäts-/Testgaps
 
-1. Es gibt keine Coverage-Metriken.
-2. Es gibt keinen dedizierten Last-/Soak-Test für Worker unter hoher Last.
-3. Es gibt keinen dedizierten automationsgestützten Test für reale Response-Header auf dem Produktiv-Host.
+1. Es gibt keinen dedizierten Last-/Soak-Test für Worker unter hoher Last.
+2. Es gibt keinen dedizierten automationsgestützten Test für reale Response-Header auf dem Produktiv-Host.
+3. `src/App.tsx` und `src/main.tsx` bleiben im Vergleich zu Kern-Libs unterdurchschnittlich unit-/integrationsgetestet.
 
 ## Betriebsgaps
 
@@ -33,7 +33,7 @@
 
 1. Security-Header-Strategie für produktives Hosting festlegen.
 2. Secret-/Env-Hygiene absichern und CI um Secret-Scanning ergänzen.
-3. Coverage-Messung und Mindestschwellen einführen.
+3. Coverage-Baseline halten und Schwellen nur bei stabil nachgewiesenem Testzuwachs anheben.
 
 ### Should-have
 

--- a/docs/qa-coverage-finalization.md
+++ b/docs/qa-coverage-finalization.md
@@ -1,0 +1,164 @@
+# QA/Coverage Finalization (Stand: 2026-03-09)
+
+## 1. Executive Summary
+
+Die in Phase A, B und C integrierten Maßnahmen wurden auf `main` konsolidiert und auf einen einheitlichen Endstand gebracht.
+Der technische Endstand für QA/Coverage ist jetzt konsistent dokumentiert, widersprüchliche Alt-Aussagen wurden bereinigt, und historische Zwischenstands-Dokumente sind klar als nicht maßgeblich markiert.
+
+Maßgeblich für den Endstand sind:
+
+- `vitest.config.ts` (Coverage-Definition)
+- `.github/workflows/quality.yml` (CI-Gates)
+- `docs/testing.md` (laufende Teststrategie)
+- `docs/qa-coverage-finalization.md` (diese Datei als Endstandsreferenz)
+
+## 2. Konsolidierter finaler QA-/Coverage-Stand
+
+- Unit-/Integrationsnahe Tests laufen über Vitest (`src/**/*.test.ts(x)`).
+- Browser-QA ist getrennt in Lighthouse + Playwright/Axe abgebildet.
+- Unit-Coverage ist aktiv und gate-relevant (global thresholds in `vitest.config.ts`).
+- Release-Hygiene und Dependency-Audits sind im schnellen CI-Gate enthalten.
+- Historische Phasenprotokolle bleiben zur Nachvollziehbarkeit erhalten, definieren aber nicht mehr den aktuellen Sollzustand.
+
+## 3. Finaler Zuschnitt der Testpyramide im Repo
+
+1. Unit-/modulnahe Integration (Vitest)
+   - Sicherheitslogik, Validierung, Routing, Worker-Client, Worker-Contract, zentrale UI-Zustandskomponenten.
+2. Browser-E2E (Playwright)
+   - Kernflüsse aus Nutzerperspektive (Navigation, Suche/Filter/Sortierung, Deep-Link/Fallback, CSV-Flow).
+3. A11y (Playwright + Axe)
+   - Kritische und schwerwiegende Accessibility-Verletzungen auf Kernrouten und Overlay-Zuständen.
+4. Lighthouse-Gates
+   - Performance/Accessibility/Best-Practices mit Mindestwerten und Budgets.
+5. Release-Hygiene
+   - Artefaktprüfung auf verbotene Dateien im Build-Output.
+
+## 4. Finale Coverage-Konfiguration und Begründung
+
+Quelle: `vitest.config.ts`
+
+- Provider: `v8`
+- Reporter: `text`, `text-summary`, `json-summary`, `lcov`
+- Reports-Pfad: `coverage/unit`
+- Include: `src/**/*.{ts,tsx,js}`
+- Excludes:
+  - `src/**/*.test.ts`
+  - `src/**/*.test.tsx`
+  - `src/**/*.d.ts`
+  - `src/vite-env.d.ts`
+  - `src/types.ts`
+  - `src/styles.css`
+- Globale Mindestschwellen:
+  - `lines: 30`
+  - `functions: 34`
+  - `branches: 24`
+  - `statements: 30`
+
+Begründung:
+
+- Der Zuschnitt misst echte App-Implementierung unter `src/`.
+- Testdateien, Typ-Deklarationen und Styling werden bewusst nicht in Prozentkennzahlen eingerechnet.
+- Generierte Artefakte (`public/data/**`, `public/sw.js`) liegen außerhalb der Coverage-Zielmenge.
+- Schwellen liegen über "nur Build-grün", bleiben aber robust genug für inkrementelle Weiterentwicklung ohne kosmetische Ausschlüsse.
+
+## 5. Finale CI-/Gate-Strategie
+
+Quelle: `.github/workflows/quality.yml`
+
+- Job `qa` (schneller Pflicht-Gate):
+  - Dependency Audit (`audit:prod`, `audit:dev`)
+  - Unit-Coverage-Gate (`test:unit:coverage`)
+  - Release-Hygiene (`check:release-hygiene`)
+  - Coverage-Artefakt-Upload (`coverage/unit`)
+- Job `browser-qa` (schwerer, nachgelagert):
+  - Build
+  - `qa:browser` (Lighthouse + Playwright/Axe)
+
+Konsolidierungsentscheidung:
+
+- Die bestehende Zweiteilung wurde beibehalten, da sie schnelle Pflichtsignale und schwerere Browserprüfungen sauber trennt.
+- Keine zusätzliche Workflow-Variante eingeführt, um konkurrierende Gate-Pfade zu vermeiden.
+
+## 6. Bewusste Excludes und Nicht-Ziele
+
+Bewusste Excludes:
+
+- Generierte Outputs: `public/data/**`, `public/sw.js`, `dist/**`
+- Test-/Report-Artefakte: `coverage/**`, `.lighthouseci/**`, `test-results/**`, `playwright-report/**`
+- Nicht-codebezogene Inhalte: `docs/**`, `Kataloge/**`, `.github/**`
+
+Nicht-Ziele dieser Finalisierung:
+
+- Keine neue Phase D / keine neue Testoffensive.
+- Keine großflächigen Refactorings von `App.tsx` oder Worker-Architektur.
+- Keine neuen fachlichen Produktfeatures.
+
+## 7. Inkonsistenzen/Altlasten und wie sie aufgelöst wurden
+
+Aufgelöste Inkonsistenzen:
+
+1. Widerspruch in `docs/testing.md` (Coverage konfiguriert vs. "Coverage-Reports sind nicht konfiguriert") entfernt.
+2. Veraltete Aussage in `docs/architecture.md` ("Keine Coverage-Messung konfiguriert") korrigiert.
+3. Veraltete Gap-Aussage in `docs/open-issues-and-gaps.md` ("Es gibt keine Coverage-Metriken") ersetzt.
+4. Historische Phase-A/B/C-Dokumente als historische Umsetzungsprotokolle markiert, mit Verweis auf diese Finaldatei.
+5. `.gitignore` um `coverage` ergänzt, damit lokale Coverage-Ausgaben keinen unnötigen Git-Noise erzeugen.
+
+Verbleibender historischer Kontext:
+
+- `docs/coverage-phase-a-implementation.md`
+- `docs/coverage-phase-b-implementation.md`
+- `docs/coverage-phase-c-implementation.md`
+
+Diese Dokumente bleiben für Verlauf und Reviewbarkeit erhalten, sind aber nicht mehr normativ.
+
+## 8. Verbleibende Restlücken / Risiken
+
+1. `src/App.tsx` und `src/main.tsx` sind weiterhin unterdurchschnittlich fein granular abgesichert.
+2. Kein dedizierter Last-/Soak-Test für Worker unter hoher Last.
+3. Kein automatisierter Testpfad für reale Produktiv-Header außerhalb der Repository-CI.
+4. TypeScript bleibt bei `strict: false`; potenzielle Typregressionen werden nicht maximal früh erkannt.
+
+Diese Punkte sind bekannt, akzeptiert und bewusst nicht im Rahmen dieser Finalisierung erweitert worden.
+
+## 9. Ausgeführte Validierungsschritte und Ergebnis
+
+Lokal ausgeführt auf Branch `chore/qa-coverage-finalization`:
+
+1. `npm run test:unit:coverage`
+   - Ergebnis: erfolgreich
+   - Testdateien: 22
+   - Tests: 95 (alle grün)
+   - Coverage Summary:
+     - Statements: 42.17%
+     - Branches: 37.31%
+     - Functions: 39.95%
+     - Lines: 42.35%
+   - Schwellen eingehalten: ja
+
+2. `npm run qa`
+   - Ergebnis: erfolgreich
+   - Enthält erfolgreich:
+     - `npm run build`
+     - `npm run test:unit:raw`
+     - `npm run check:release-hygiene`
+     - `npm run qa:browser` (Lighthouse + Playwright/Axe)
+   - Browser-QA:
+     - Lighthouse: erfolgreich
+     - Playwright/Axe: 18/18 Tests bestanden
+
+3. `npm run audit:prod && npm run audit:dev`
+   - Ergebnis: erfolgreich
+   - `audit:prod`: 0 vulnerabilities
+   - `audit:dev`: keine kritischen/hohen Befunde (Hinweise für low/moderate vorhanden)
+
+Nebenbefunde:
+
+- Build erzeugt erwartungsgemäß generierte Artefakte unter `public/data/**` und `public/sw.js`.
+- Keine Änderung am GitHub-Pages-Verhalten.
+
+## 10. Klare Einschätzung: finalisiert oder noch nicht finalisiert
+
+Einschätzung: **finalisiert**.
+
+Der QA-/Coverage-Endstand ist konsistent, überprüfbar und wartbar dokumentiert.
+Die verbleibenden Lücken sind klar benannt, bewusst akzeptiert und nicht Ergebnis von unbeabsichtigter Inkonsistenz.

--- a/docs/qa-coverage-maintenance-summary.md
+++ b/docs/qa-coverage-maintenance-summary.md
@@ -1,0 +1,41 @@
+# QA/Coverage Maintenance Summary
+
+## 1. Was ist der aktuelle QA-/Coverage-Endstand?
+
+- Unit-Coverage ist aktiv und als CI-Gate etabliert.
+- Schneller Pflicht-Gate (`quality / qa`) ist von schwerer Browser-QA getrennt.
+- Maßgebliche Endstandsreferenz: `docs/qa-coverage-finalization.md`.
+
+## 2. Welche Konfiguration ist maßgeblich?
+
+- Unit-/Coverage-Konfiguration: `vitest.config.ts`
+- CI-Gates: `.github/workflows/quality.yml`
+- Laufende Teststrategie: `docs/testing.md`
+- Endstandsentscheidung: `docs/qa-coverage-finalization.md`
+
+## 3. Welche Checks sind verpflichtend?
+
+Verpflichtender schneller CI-Gate (`qa`):
+
+1. `npm run audit:prod && npm run audit:dev`
+2. `npm run test:unit:coverage`
+3. `npm run check:release-hygiene`
+
+Nachgelagerter schwerer QA-Gate (`browser-qa`):
+
+1. `npm run build`
+2. `npm run qa:browser` (Lighthouse + Playwright/Axe)
+
+## 4. Welche Bereiche bleiben bewusst außerhalb der Coverage-Ziele?
+
+- Generierte Artefakte (`public/data/**`, `public/sw.js`, `dist/**`)
+- Test-/Report-Ausgaben (`coverage/**`, `.lighthouseci/**`, `test-results/**`, `playwright-report/**`)
+- Nicht-Quellcodebereiche (`docs/**`, `.github/**`, `Kataloge/**`)
+- Testdateien und Typ-Deklarationen (`*.test.*`, `*.d.ts`, `src/types.ts`)
+
+## 5. Welche bekannten Restlücken sind akzeptiert?
+
+1. Begrenzte direkte Tests für `src/App.tsx` und `src/main.tsx`.
+2. Kein dedizierter Worker-Last-/Soak-Test.
+3. Kein automatisierter Produktiv-Header-Testpfad in der Repository-CI.
+4. TypeScript weiterhin `strict: false`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,102 +1,105 @@
 # Testing
 
-## Teststrategie
+## Maßgeblicher Stand
 
-### 1) Unit-Tests (Vitest)
+Der maßgebliche QA-/Coverage-Endstand ist in `docs/qa-coverage-finalization.md` beschrieben.
+Diese Datei (`docs/testing.md`) beschreibt die laufende Teststrategie und verweist auf die dafür gültigen Konfigurationsquellen.
 
-- Konfiguration in `vitest.config.ts` (`src/**/*.test.ts(x)`, Environment `node`).
-- Schwerpunkte:
-  - CSV/Export-Härtung (`csv`, `controlExport`)
-  - URL-Sicherheit (`urlSafety`)
-  - Routing-Härtung (`routing`)
-  - Datenschema-Validierung inkl. Budgetgrenzen (`dataSchemas`)
-  - Worker-Vertragsgrenze (`searchWorker`, `searchClient`)
-  - statisches Rendering zentraler UI-Komponenten
+## Testpyramide im Repository
 
-### Coverage-Gates
+### 1) Unit- und modulnahe Integrationstests (Vitest)
 
-- Unit-Coverage wird über `vitest --coverage` (Provider `v8`) gemessen.
-- Berichte liegen unter `coverage/unit`.
-- Aktive Mindestschwellen:
+- Konfiguration: `vitest.config.ts`
+- Testquellen: `src/**/*.test.ts`, `src/**/*.test.tsx`
+- Environment: `node`
+- Schwerpunkt:
+  - Sicherheits- und Validierungslogik (`csv`, `urlSafety`, `searchSafety`, `validation`, `fetchJsonSafe`, `dataSchemas`)
+  - Routing- und Worker-Client-Vertragsgrenzen (`routing`, `searchClient`)
+  - Worker-Contract-Grenzen (`searchWorker`)
+  - zentrale UI-Zustandspfade auf Komponentenebene (`ResultList`, `GroupPage`, weitere Kernkomponenten)
+
+### 2) Browser-E2E (Playwright)
+
+- Konfiguration: `playwright.a11y.config.ts`
+- Kernflüsse: `tests/core-flows.spec.ts`
+- Fokus: Navigation, Suche/Filter/Sortierung, Deep-Link-Fallbacks, CSV-Flow
+
+### 3) Accessibility (Playwright + Axe)
+
+- Datei: `tests/a11y.spec.ts`
+- Fokus: kritische/ernsthafte Violations auf relevanten Routen und Overlay-Zuständen
+
+### 4) Performance-/Qualitätsgates (Lighthouse)
+
+- Konfiguration: `lighthouserc.json`
+- Fokus: Performance, Accessibility, Best Practices sowie ausgewählte Budgets
+
+### 5) Release-Hygiene
+
+- Skript: `scripts/check-release-hygiene.mjs`
+- Prüft verbotene Artefakte in `dist/` (z. B. `.DS_Store`, `.map`)
+
+## Finale Coverage-Konfiguration (Unit)
+
+Konfiguriert in `vitest.config.ts`:
+
+- Provider: `v8`
+- Reports: `text`, `text-summary`, `json-summary`, `lcov`
+- Ausgabepfad: `coverage/unit`
+- Include: `src/**/*.{ts,tsx,js}`
+- Excludes:
+  - `src/**/*.test.ts`
+  - `src/**/*.test.tsx`
+  - `src/**/*.d.ts`
+  - `src/vite-env.d.ts`
+  - `src/types.ts`
+  - `src/styles.css`
+- Aktive Mindestschwellen (global):
   - `lines: 30`
   - `functions: 34`
   - `branches: 24`
   - `statements: 30`
 
-### 2) End-to-End-Tests (Playwright)
+Hinweis: Generierte Artefakte (`public/data/**`, `public/sw.js`) liegen bewusst außerhalb der Unit-Coverage-Messung.
 
-- `tests/core-flows.spec.ts` deckt Kernflows ab:
-  - Such-/Filter-/Sortierflüsse
-  - responsive Breakpoints
-  - Overlay-/Fokusverhalten
-  - CSV-UI-Flows
+## CI-/Gate-Strategie
 
-### 3) Accessibility-Tests
+Workflow: `.github/workflows/quality.yml`
 
-- `tests/a11y.spec.ts` mit `@axe-core/playwright`.
-- Prüfung auf critical/serious Violations auf definierten Routen und mit offenem Overlay.
+1. `qa` (schneller, PR-pflichtiger Gate):
+   - `npm run audit:prod && npm run audit:dev`
+   - `npm run test:unit:coverage`
+   - `npm run check:release-hygiene`
+   - Upload des Coverage-Artefakts (`coverage/unit`)
+2. `browser-qa` (schwerer Lauf, nach `qa`):
+   - Build
+   - Lighthouse
+   - Playwright/Axe
 
-### 4) Performance-/Qualitätsgates
+Diese Trennung hält den Pflicht-Gate schnell und verschiebt browsernahe, langsamere Prüfungen in einen separaten Lauf.
 
-- Lighthouse CI (`lighthouserc.json`) mit Mindestwerten/Budgets.
-
-### 5) Release-Hygiene
-
-- Skript prüft verbotene Artefakte in `dist/` (`.DS_Store`, `.map`).
-
-## Testausführung
-
-### Lokal
+## Relevante lokale Kommandos
 
 ```bash
 npm run test:unit
 npm run test:unit:coverage
+npm run build
+npm run check:release-hygiene
 npm run qa
 ```
 
-Hinweis: `public/data/**` und `public/sw.js` sind nicht versioniert und werden im Build erzeugt. `npm run test:unit` führt deshalb intern zuerst `npm run build` aus.
+Hinweis: `npm run test:unit` und `npm run test:unit:coverage` führen intern zuerst `npm run build` aus, damit generierte Datenartefakte lokal verfügbar sind.
 
-### CI
+## Verbleibende bekannte Lücken
 
-Workflow `.github/workflows/quality.yml` führt getrennte Gates aus:
-1. `qa` (schnell, PR-pflichtig): Audit, Unit-Coverage-Gate, Release-Hygiene
-2. `browser-qa` (schwerer): Build, Lighthouse, Playwright/Axe
+1. Kein dedizierter Last-/Soak-Test für Worker unter hoher Last.
+2. Kein automatisierter Produktiv-Header-Testpfad außerhalb der Repository-CI.
+3. `src/App.tsx` und `src/main.tsx` bleiben im Vergleich zu Kern-Libs unterdurchschnittlich fein granular getestet.
 
-## Nachgewiesene lokale Läufe (2026-03-06)
+## Historische Dokumente
 
-- `npm run test:unit`
-  - 13 Testdateien
-  - 34 Tests
-  - alle erfolgreich
+- `docs/coverage-phase-a-implementation.md`
+- `docs/coverage-phase-b-implementation.md`
+- `docs/coverage-phase-c-implementation.md`
 
-- `npm run build`
-  - erfolgreich
-
-- `npm run check:release-hygiene`
-  - erfolgreich
-
-## Coverage-Hinweise
-
-- Coverage-Reports sind nicht konfiguriert.
-
-## Testlücken
-
-1. Kein dedizierter Integrationstest für Worker-Protokollgrenzen unter Last.
-2. Kein Snapshot-/Regressionstest für komplette Seitenzustände.
-3. Kein dedizierter automationsgestützter Test für reale Response-Header auf dem Produktiv-Host.
-
-## Empfohlene Prioritäten
-
-### Must-have
-
-1. Coverage-Messung in CI ergänzen und Schwellwerte definieren.
-2. Kritische Worker-Flows (Timeout/Cancel/Budget) mit gezielten Integrationstests absichern.
-
-### Should-have
-
-1. E2E-Tests für Graph-Klickpfade erweitern.
-2. Zusätzliche Integrationsprüfungen für Host-spezifisches Laufzeitverhalten ergänzen.
-
-### Nice-to-have
-
-1. Performance-Regressionstests für Suchlatenz und Graphaufbau ergänzen.
+Diese Dateien sind Implementierungsprotokolle der Zwischenstände und nicht die maßgebliche Endstandsdefinition.


### PR DESCRIPTION
## Summary
- consolidate the already-merged Phase A/B/C QA and coverage work into one authoritative final state
- add a central finalization document and a maintenance summary for ongoing ownership
- harmonize conflicting documentation statements and mark phase docs as historical
- add coverage to .gitignore to prevent local report noise

## Files
- .gitignore
- README.md
- docs/architecture.md
- docs/testing.md
- docs/open-issues-and-gaps.md
- docs/coverage-phase-a-implementation.md
- docs/coverage-phase-b-implementation.md
- docs/coverage-phase-c-implementation.md
- docs/qa-coverage-finalization.md
- docs/qa-coverage-maintenance-summary.md

## Validation
- npm run test:unit:coverage
- npm run qa
- npm run audit:prod && npm run audit:dev

## Notes
- no product behavior changes
- no workflow logic changes; existing gate split (qa and browser-qa) remains the chosen final structure
- existing local untracked file docs/qa-coverage-gap-analysis.md was intentionally left unchanged