### PR TITLE
chore: deploy pages only after successful quality run

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,7 +1,9 @@
 name: deploy-pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ["quality"]
+    types: [completed]
     branches: ["main"]
   workflow_dispatch:
 
@@ -16,11 +18,16 @@ concurrency:
 
 jobs:
   build:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ npm run audit:dev
 ### GitHub Pages
 
 - Workflow: `.github/workflows/deploy-pages.yml`
+- Trigger: automatisch nach erfolgreichem `quality`-Run auf `main` sowie manuell via `workflow_dispatch`
 - setzt `VITE_BASE_PATH=/${{ github.event.repository.name }}/`
 - benötigt folgende Secrets:
   - `VITE_OPERATOR_NAME`

--- a/docs/setup-and-operations.md
+++ b/docs/setup-and-operations.md
@@ -78,7 +78,7 @@ Enthält Build, Unit-Tests, Release-Hygiene, Lighthouse und Playwright-A11y.
 ### GitHub Pages
 
 - Workflow: `.github/workflows/deploy-pages.yml`
-- Trigger: Push auf `main` und `workflow_dispatch`
+- Trigger: `workflow_run` nach erfolgreichem `quality`-Run auf `main` sowie `workflow_dispatch`
 - Build-Artefakt: `dist/`
 - Secrets: `VITE_OPERATOR_*`
 
@@ -113,7 +113,7 @@ Empfohlener Required Status Check:
 
 Merge-Queue-Kompatibilität:
 - Der Qualitätsworkflow triggert auf `pull_request` und `merge_group`.
-- `deploy-pages.yml` ist absichtlich kein Required PR-Check, da Deployment erst nach Merge auf `main` läuft.
+- `deploy-pages.yml` ist absichtlich kein Required PR-Check, da Deployment erst nach Merge auf `main` läuft und auf einen erfolgreichen `quality`-Run wartet.
 - `daily-bsi-sync.yml` ist eine Automationspipeline und ebenfalls kein Required PR-Check für Feature-PRs.
 
 Hinweis zu Auto-merge:


### PR DESCRIPTION
## Summary
- switch GitHub Pages deploy trigger from direct push to workflow_run of quality on main
- require successful quality conclusion before running deploy jobs
- checkout the exact tested head SHA from the triggering quality run
- update README and setup docs to reflect the new deploy gating model

## Why
- ensures QA-before-deploy as an enforced workflow invariant
- keeps deploy separate from PR required checks while preventing premature deployment

## Files
- .github/workflows/deploy-pages.yml
- README.md
- docs/setup-and-operations.md

## Validation
- npm run build
- npm run test:unit
- npm run check:release-hygiene

## Notes
- manual workflow_dispatch deploy remains available
- existing local untracked file docs/qa-coverage-gap-analysis.md was intentionally left unchanged