### PR TITLE
fix: stabilize flaky overlay clear focus browser qa check

### DIFF
--- a/tests/core-flows.spec.ts
+++ b/tests/core-flows.spec.ts
@@ -94,14 +94,18 @@ test.describe("Kernflows", () => {
     await expect(page.locator('[data-search-results-focus="results"], [data-search-results-focus="status"]')).toBeFocused();
 
     await page.getByRole("button", { name: "Suche öffnen" }).click();
-    await expect(overlayDialog.getByRole("searchbox", { name: "Suche" })).toHaveValue("");
+    const reopenedSearchInput = overlayDialog.getByRole("searchbox", { name: "Suche" });
+    await expect(reopenedSearchInput).toHaveValue("");
     await expect(overlayDialog.getByRole("button", { name: "Suchtext leeren" })).toHaveCount(0);
-    await overlayDialog.getByRole("searchbox", { name: "Suche" }).fill("abc");
+    await reopenedSearchInput.fill("abc");
     await overlayDialog.getByRole("button", { name: "Suchtext leeren" }).click();
     await expect(page).not.toHaveURL(/q=/);
     await expect(overlayDialog).toBeVisible();
-    await expect(overlayDialog.getByRole("searchbox", { name: "Suche" })).toHaveValue("");
-    await expect(overlayDialog.getByRole("searchbox", { name: "Suche" })).toBeFocused();
+    await expect(reopenedSearchInput).toHaveValue("");
+    await page.keyboard.type("x");
+    await expect(reopenedSearchInput).toHaveValue("x");
+    await page.keyboard.press("Backspace");
+    await expect(reopenedSearchInput).toHaveValue("");
     await expect(overlayDialog.getByRole("button", { name: "Suchtext leeren" })).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- fix intermittent browser-qa failure in tests/core-flows.spec.ts (Suche per Overlay Enter und Clear)
- replace brittle toBeFocused assertion after clear with a functional keyboard-focus assertion
- keep behavior expectation: overlay stays open, input clears, and keyboard input goes directly into the search field

## Root cause
- flaky timing around focus assertion in CI (observed on push run 22865742723)
- PR run and push run executed the same test path with different timing outcomes (classic non-deterministic UI focus check)

## Validation
- focused stress run: start-server-and-test + playwright repeat-each=20, workers=2 (20/20 pass)
- npm run qa (pass)

## Scope
- test-only change in tests/core-flows.spec.ts
- no product logic changes

## Note
- existing local untracked file docs/qa-coverage-gap-analysis.md remains unchanged