### PR TITLE
test: stabilize search overlay clear flow in browser QA

### DIFF
--- a/tests/core-flows.spec.ts
+++ b/tests/core-flows.spec.ts
@@ -102,6 +102,8 @@ test.describe("Kernflows", () => {
     await expect(page).not.toHaveURL(/q=/);
     await expect(overlayDialog).toBeVisible();
     await expect(reopenedSearchInput).toHaveValue("");
+    await reopenedSearchInput.focus();
+    await expect(reopenedSearchInput).toBeFocused();
     await page.keyboard.type("x");
     await expect(reopenedSearchInput).toHaveValue("x");
     await page.keyboard.press("Backspace");


### PR DESCRIPTION
## Summary
- fix flaky Playwright step in `Kernflows › Suche per Overlay Enter und Clear`
- explicitly focus the reopened search input before typing via `page.keyboard`
- keep the keyboard-based assertion path while removing timing sensitivity

## Root cause
The failing CI job (`browser-qa`) hit a timing race after clicking "Suchtext leeren": keyboard typing sometimes happened while no element was focused.

## Validation
- `npx start-server-and-test preview http://127.0.0.1:4173 "playwright test --config=playwright.a11y.config.ts --grep 'Suche per Overlay Enter und Clear'"`
- `npx start-server-and-test preview http://127.0.0.1:4173 "npm run qa:a11y"`
- `npm run qa:browser`
