### PR TITLE
test: stabilize flaky overlay backspace assertion

### DIFF
--- a/tests/core-flows.spec.ts
+++ b/tests/core-flows.spec.ts
@@ -104,8 +104,10 @@ test.describe("Kernflows", () => {
     await expect(reopenedSearchInput).toHaveValue("");
     await reopenedSearchInput.fill("x");
     await expect(reopenedSearchInput).toHaveValue("x");
+    await reopenedSearchInput.click();
+    await expect(reopenedSearchInput).toBeFocused();
     await reopenedSearchInput.press("Backspace");
-    await expect(reopenedSearchInput).toHaveValue("");
+    await expect.poll(async () => reopenedSearchInput.inputValue()).toBe("");
     await expect(overlayDialog.getByRole("button", { name: "Suchtext leeren" })).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- stabilize the flaky keyboard-clear assertion in `tests/core-flows.spec.ts`
- explicitly focus the reopened search input before sending `Backspace`
- use `expect.poll(...inputValue())` to assert eventual empty state reliably

## Why
`browser-qa` on `main` failed in run `22922271801` (job `66523611907`) because the test occasionally kept value `"x"` after `Backspace`.

## Validation
- `npx start-server-and-test preview http://127.0.0.1:4173 "npx playwright test tests/core-flows.spec.ts -g 'Suche per Overlay Enter und Clear' --config=playwright.a11y.config.ts"`
- `npm run qa:browser`
