### PR TITLE
refactor: complete EH-02 single-catalog contract cleanup

### DIFF
--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -18,7 +18,6 @@ const swTemplatePath = path.join(rootDir, "scripts", "sw.template.js");
 const swOutputPath = path.join(rootDir, "public", "sw.js");
 
 const catalogSource = {
-  id: "anwender",
   label: "Anwenderkatalog",
   sourcePath: path.join(rootDir, "Kataloge", "Grundschutz++-catalog.json")
 };
@@ -56,8 +55,6 @@ async function main() {
     buildTimestamp: new Date().toISOString(),
     appVersion: pkg.version,
     indexVersion: "2",
-    datasetId: catalogSource.id,
-    datasetLabel: catalogSource.label,
     catalogFileName: basename(catalogSource.sourcePath),
     catalogFileSha256: sourceHash,
     catalogFileSizeBytes: sourceSizeBytes

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,7 +139,7 @@ function getInitialTheme(): ThemeMode {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-function getDatasetPaths() {
+function getCatalogAssetPaths() {
   return {
     metaUrl: assetUrl("./data/catalog-meta.json"),
     indexUrl: assetUrl("./data/catalog-index.json"),
@@ -243,7 +243,7 @@ export default function App() {
   }
 
   async function initializeDataset() {
-    const paths = getDatasetPaths();
+    const paths = getCatalogAssetPaths();
 
     setBootState("loading");
     setBootError(null);

--- a/src/lib/dataSchemas.test.ts
+++ b/src/lib/dataSchemas.test.ts
@@ -18,12 +18,9 @@ function readJson(relativePath: string) {
 }
 
 function findSampleDetailChunkPath() {
-  const candidates = ["public/data/details", "public/data/datasets/anwender/details"];
-  for (const relativeDir of candidates) {
-    const fullDir = path.join(rootDir, relativeDir);
-    if (!existsSync(fullDir)) {
-      continue;
-    }
+  const relativeDir = "public/data/details";
+  const fullDir = path.join(rootDir, relativeDir);
+  if (existsSync(fullDir)) {
     const firstJson = readdirSync(fullDir).find((entry) => entry.endsWith(".json"));
     if (firstJson) {
       return path.join(relativeDir, firstJson);

--- a/src/lib/dataSchemas.ts
+++ b/src/lib/dataSchemas.ts
@@ -16,8 +16,6 @@ const BuildInfoSchema = z
     buildTimestamp: shortString,
     appVersion: shortString,
     indexVersion: shortString,
-    datasetId: shortString.optional(),
-    datasetLabel: mediumString.optional(),
     catalogFileName: shortString,
     catalogFileSha256: z.string().regex(/^[a-f0-9]{64}$/i),
     catalogFileSizeBytes: z.number().int().nonnegative().max(SECURITY_BUDGETS.maxCatalogFileSizeBytes)

--- a/src/lib/securityBudgets.ts
+++ b/src/lib/securityBudgets.ts
@@ -3,8 +3,6 @@ export const SECURITY_BUDGETS = {
   maxRemoteJsonBytes: {
     catalogIndex: 3 * 1024 * 1024,
     catalogMeta: 1 * 1024 * 1024,
-    profileLinks: 512 * 1024,
-    catalogRegistry: 256 * 1024,
     detailChunk: 2 * 1024 * 1024
   },
   maxQueryChars: 180,

--- a/src/styles.css
+++ b/src/styles.css
@@ -731,25 +731,6 @@ summary:focus-visible,
   flex-wrap: wrap;
 }
 
-.dataset-badge {
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--secondary-bg);
-  color: var(--text);
-  font-size: 0.85rem;
-  padding: 0.15rem 0.6rem;
-  max-width: 220px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: border-color 120ms ease, background 120ms ease;
-}
-
-.dataset-badge:hover {
-  border-color: var(--accent);
-}
-
 .theme-badge {
   border-radius: 999px;
   border: 1px solid var(--line);
@@ -772,52 +753,6 @@ summary:focus-visible,
   background: var(--chip);
   color: var(--chip-text);
   border-color: var(--chip-line);
-}
-
-.dataset-badge-wrap {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-}
-
-.dataset-tooltip {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
-  z-index: 220;
-  min-width: 240px;
-  max-width: 300px;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  box-shadow: var(--shadow);
-  background: var(--panel-strong);
-  color: var(--text);
-  padding: 0.55rem 0.65rem;
-  display: grid;
-  gap: 0.3rem;
-}
-
-.dataset-tooltip-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.dataset-tooltip-header strong {
-  margin: 0;
-  color: var(--text);
-}
-
-.dataset-tooltip-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.dataset-tooltip span {
-  font-size: 0.83rem;
-  color: var(--text-muted);
 }
 
 .search-controls {
@@ -896,16 +831,6 @@ summary:focus-visible,
   line-height: 1;
 }
 
-.dataset-select {
-  border: 1px solid var(--line);
-  border-radius: 11px;
-  background: var(--input-bg);
-  color: var(--text);
-  padding: 0.48rem 0.62rem;
-  min-width: 200px;
-  min-height: 44px;
-}
-
 .secondary.active {
   border-color: var(--accent);
   box-shadow: inset 0 0 0 1px var(--accent);
@@ -947,11 +872,6 @@ summary:focus-visible,
 
 .hero-card h1 {
   margin: 0;
-}
-
-.hero-dataset-picker {
-  margin-left: auto;
-  flex: 0 0 auto;
 }
 
 .hero-stats {


### PR DESCRIPTION
## Summary
- rename getDatasetPaths to getCatalogAssetPaths to reflect the single-catalog runtime contract
- remove legacy datasetId and datasetLabel from generated build-info.json and runtime schema validation
- remove leftover legacy remote-size budget fields for profileLinks and catalogRegistry
- drop obsolete dataset-only CSS classes and remove legacy dataset detail fallback path from schema tests

## Validation
- npm run build:data
- npm run test:unit
- npm run build
- npm run check:release-hygiene

## Epic tracking
- Continues #46 (EH-02)
