### PR TITLE
docs: synchronize EH-04 docs with single-catalog runtime contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Die App macht den Katalog im Browser nutzbar, ohne eigenes Backend:
 - Keine Schreiboperationen gegen externe Systeme
 - Kein Compliance- oder Zertifizierungsversprechen durch die Anwendung selbst
 
+## Verbindlicher Scope (Single-Catalog)
+
+- Die Anwendung verarbeitet genau einen Katalog: `Kataloge/Grundschutz++-catalog.json`.
+- Zur Laufzeit gibt es keine Dataset-Auswahl in der UI.
+- Manueller JSON-Upload ist kein Produktumfang (kein Upload-UI, kein Upload-State, kein Upload-Worker-Protokoll).
+- Legacy-Pfade wie `public/data/datasets` bzw. Registry/Profile werden beim Build aktiv bereinigt.
+
 ## Routing (Hash-basiert)
 
 - `#/`
@@ -65,6 +72,7 @@ Wichtige Hinweise:
 - `npm run build` erzeugt Datenartefakte und den Service Worker neu.
 - `npm run test:unit` führt intern zuerst `npm run build` aus.
 - `public/data/**` und `public/sw.js` sind generierte Artefakte und in Git ignoriert.
+- `npm run build:data` schreibt den Single-Catalog-Vertrag und entfernt Legacy-Artefakte aus früheren Multi-Dataset-Ansätzen.
 
 ## Wichtige Skripte
 

--- a/docs/api-and-interfaces.md
+++ b/docs/api-and-interfaces.md
@@ -15,6 +15,16 @@ Eigenschaften:
 - Build-Output, nicht als handgepflegte Quelle behandeln
 - wird bei `npm run build:data` / `npm run build` neu erzeugt
 - wird per `src/lib/dataSchemas.ts` (Zod) validiert
+- Single-Catalog-Vertrag: keine `datasetId`-/`datasetLabel`-Felder im BuildInfo-Schema
+- Legacy-Ausgaben (`public/data/datasets`, `catalog-registry.json`, `profile-links.json`) werden im Build entfernt
+
+`build-info.json` enthält:
+- `buildTimestamp`
+- `appVersion`
+- `indexVersion`
+- `catalogFileName`
+- `catalogFileSha256`
+- `catalogFileSizeBytes`
 
 ## 2) Worker-Protokoll (`SearchClient` <-> `searchWorker`)
 
@@ -34,6 +44,10 @@ Sicherheits-/Robustheitsaspekte:
 - Zeit-/Mengenbudgets im Worker
 - Validierung externer JSON-Payloads
 
+Nicht vorhanden (bewusst ausgeschlossen):
+- kein Upload-Request-Typ
+- kein Dataset-Registry-Handshake
+
 ## 3) Routing-Schnittstelle
 
 Routen:
@@ -50,6 +64,10 @@ Routen:
 - Text/Sort: `q`, `sort`
 - Facetten: `tg`, `gid`, `sec`, `eff`, `cls`, `mod`, `tgt`, `tag`, `rel`
 - Detailkontext: `control`, `top`
+
+Nicht vorhanden (bewusst ausgeschlossen):
+- keine Hash-Route für manuellen JSON-Upload
+- keine Route zur Datensatz-Auswahl
 
 ## 4) CSV-Export-Schnittstelle
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,14 @@ Die Anwendung ist eine rein statische Client-Side-React-App (CSR) ohne eigenes B
 - Generierte Runtime-Artefakte: `public/data/**`, `public/sw.js`
 - Hostingziel: statische Hosts (primär GitHub Pages)
 
+## Verbindlicher Runtime-/Artefakt-Vertrag (EH-02/EH-03)
+
+- Single-Catalog: Build-Input ist ausschließlich `Kataloge/Grundschutz++-catalog.json`.
+- Feste Runtime-Pfade: `./data/catalog-meta.json`, `./data/catalog-index.json`, `./data/details`.
+- Kein Dataset-Switching in der UI.
+- Kein manueller JSON-Upload (kein Upload-UI, kein Upload-State, kein Upload-Worker-Protokoll).
+- Build bereinigt Legacy-Ausgaben (`public/data/datasets`, `catalog-registry.json`, `profile-links.json`).
+
 ## Informationsarchitektur und Routing
 
 Hash-Routing ist bewusst gewählt (kein History-Rewrite erforderlich):
@@ -26,6 +34,7 @@ Hash-Routing ist bewusst gewählt (kein History-Rewrite erforderlich):
 ### 1) UI-Orchestrierung (`src/App.tsx`)
 
 - bootstrapped Metadaten + Worker-Index
+- nutzt feste Asset-Pfade statt dynamischer Dataset-Registries
 - hält Routing-/UI-Zustand (Suche, Filter, Sortierung, Selektion)
 - steuert Detail-/Graph-Laden und CSV-Export-Flows
 
@@ -64,9 +73,9 @@ Hash-Routing ist bewusst gewählt (kein History-Rewrite erforderlich):
 
 ### Laufzeit
 
-1. UI lädt `./data/catalog-meta.json`.
+1. UI lädt den Katalog über feste Single-Catalog-Pfade (`./data/catalog-meta.json`).
 2. `SearchClient` initialisiert Worker mit `./data/catalog-index.json` und `./data/details`.
-3. Worker beantwortet `search`/`get-control`/`get-neighborhood`.
+3. Worker beantwortet `search`/`get-control`/`get-neighborhood` und unterstützt `cancel`.
 4. UI rendert Treffer, Detailinformationen, Relationsgraph und CSV-Export.
 
 ## Architekturgrenzen und Nicht-Ziele
@@ -83,3 +92,7 @@ Hash-Routing ist bewusst gewählt (kein History-Rewrite erforderlich):
 - Sicherheitsrelevante Logik (URL-Härtung, CSV-Neutralisierung, Routing-/Query-Sanitizing) in dedizierten Lib-Modulen
 - TypeScript `strict` ist derzeit `false`
 - keine dedizierte Lint-/Format-Pipeline in `package.json`
+
+Siehe auch:
+- `docs/api-and-interfaces.md` (konkrete Schnittstellenverträge)
+- `docs/security-review.md` (Sicherheitsannahmen und Restrisiken)

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -14,6 +14,12 @@ Es ist kein externes Penetrationstest-Zertifikat und kein Compliance-Nachweis.
 - Fail-closed bei Schema-/Budgetverstößen
 - Größen-/Zeit-/Mengenbudgets (`src/lib/securityBudgets.ts`)
 
+### Scope-bedingte Reduktion der Angriffsfläche
+
+- Single-Catalog-Modell mit festen Build-/Runtime-Pfaden statt freier Dataset-Auswahl.
+- Kein manueller JSON-Upload in der Runtime (kein Upload-UI, kein Upload-State, kein Upload-Worker-Protokoll).
+- Legacy-Mehrkatalog-Artefakte werden im Build aktiv bereinigt.
+
 ### Such- und Routing-Härtung
 
 - Suchtext- und Filter-Sanitizing (`src/lib/searchSafety.ts`)
@@ -50,6 +56,7 @@ Es ist kein externes Penetrationstest-Zertifikat und kein Compliance-Nachweis.
 - GitHub Pages erlaubt keine vollständige, repository-lokale Headersteuerung
 - keine dedizierte SAST-/Lint-Sicherheits-Pipeline in `package.json`
 - TypeScript läuft mit `strict: false`
+- bei künftiger Wiedereinführung von Upload-Funktionen entstünde zusätzlicher Validierungs- und Missbrauchsaufwand
 
 ## 4) Operative Empfehlungen
 

--- a/docs/setup-and-operations.md
+++ b/docs/setup-and-operations.md
@@ -29,6 +29,10 @@ npm run dev
 
 `npm run dev` führt zuerst `npm run build:data` aus und startet dann Vite.
 
+Single-Catalog-Betriebsmodell:
+- Laufzeitdaten kommen ausschließlich aus den generierten Artefakten unter `public/data/**`.
+- Es gibt keine Runtime-Dataset-Auswahl und keinen manuellen JSON-Upload.
+
 ## 4) Build- und Release-Pipeline
 
 ```bash
@@ -48,6 +52,7 @@ Generierte Artefakte:
 - `dist/**`
 
 `public/data/**` und `public/sw.js` sind Build-Output und in `.gitignore` ausgenommen.
+`npm run build:data` entfernt zusätzlich Legacy-Ausgaben (`public/data/datasets`, `catalog-registry.json`, `profile-links.json`).
 
 ## 5) Tests und QA lokal
 
@@ -113,6 +118,9 @@ Erwartbar bei:
 - Änderungen an `Kataloge/Grundschutz++-catalog.json`
 - Änderungen an `src/lib/normalize-core.js`
 - Änderungen an `scripts/build-catalog.mjs` oder `scripts/sw.template.js`
+
+Wichtig:
+- Änderungen am Katalog erfolgen über `Kataloge/Grundschutz++-catalog.json` (z. B. via `npm run sync:bsi`), nicht über Upload-Mechanismen zur Laufzeit.
 
 ## 8) Betriebshinweise
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,6 +15,7 @@ Die Qualitätssicherung deckt drei Ebenen ab:
   - Datenvalidierung und Sicherheitslogik (`dataSchemas`, `fetchJsonSafe`, `searchSafety`, `csv`, `urlSafety`)
   - Routing-/Worker-Grenzen (`routing`, `searchClient`, `searchWorker`)
   - zentrale UI-Zustandspfade (`App`, Kernkomponenten)
+  - Single-Catalog-Regressionen in Kernkomponenten (u. a. kein Datensatz-Auswahl-UI im Header)
 
 ### Coverage-Gate
 
@@ -30,6 +31,7 @@ Die Qualitätssicherung deckt drei Ebenen ab:
 - E2E-Kernflüsse: `tests/core-flows.spec.ts`
 - A11y-Smoketests: `tests/a11y.spec.ts` (Playwright + Axe)
 - Lighthouse-Konfiguration: `lighthouserc.json`
+- Die Breakpoint-Checks verifizieren explizit, dass kein Inline-Datensatzselector gerendert wird.
 
 ## 3) Release-Hygiene
 
@@ -70,3 +72,4 @@ npm run qa
 - kein dedizierter Last-/Soak-Test für Worker unter extremer Last
 - kein automatisierter Test realer Response-Header des Produktivhostings
 - TypeScript ist nicht in `strict`-Mode
+- kein separater Pattern-Scanner, der beliebige `upload`-Tokens im Quelltext blockiert


### PR DESCRIPTION
## Summary\n- align README and core docs with the final EH-02/EH-03 contract\n- document explicit single-catalog behavior and exclusion of manual JSON upload\n- synchronize API, setup, testing, and security docs with current runtime/build behavior\n\n## Validation\n- npm run build\n\n## Notes\n- no generated artifacts committed\n- does not change GitHub Pages runtime behavior\n\nCloses #48