### PR TITLE
fix: harden CSV export guardrails for formula injection

### DIFF
--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -34,6 +34,7 @@ Es ist kein externes Penetrationstest-Zertifikat und kein Compliance-Nachweis.
 
 - Neutralisierung spreadsheet-gefährlicher Zellinhalte
 - Linkfilterung auf sichere URLs (`src/lib/csv.ts`, `src/lib/controlExport.ts`)
+- Regressions-Guardrails in `src/lib/csv.test.ts` und `src/lib/controlExport.test.ts` decken führende Whitespaces, Control-Chars, Unicode-Normalisierung, Formelpräfixe und Export-Linkfilter explizit ab (konsistent zum Doku-Sync aus EH-04/#48).
 
 ### Service-Worker-Betrieb
 

--- a/src/lib/controlExport.test.ts
+++ b/src/lib/controlExport.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { extractControlExportRow } from "./controlExport";
+import { CONTROL_EXPORT_COLUMNS, extractControlExportRow } from "./controlExport";
+import { toCsv } from "./csv";
 import type { ControlDetail } from "../types";
 
 function makeControlDetail(overrides: Partial<ControlDetail> = {}): ControlDetail {
@@ -36,12 +37,19 @@ function makeControlDetail(overrides: Partial<ControlDetail> = {}): ControlDetai
 }
 
 describe("extractControlExportRow", () => {
-  it("filtert unsichere Link-Schemes aus dem Export", () => {
+  it("filtert unsichere und obfuskierte Link-Schemes aus dem Export", () => {
     const detail = makeControlDetail({
       links: [
         { rel: "source", href: "https://example.org/a" },
-        { rel: "source", href: "javascript:alert(1)" },
-        { rel: "source", href: "data:text/plain,abc" }
+        { rel: "source", href: "http://example.org/plain" },
+        { rel: "source", href: "https://example.org/a" },
+        { rel: "source", href: " javascript:alert(1)" },
+        { rel: "source", href: "javascrıpt:alert(1)" },
+        { rel: "source", href: "data:text/plain,abc" },
+        { rel: "source", href: "blob:https://example.org/123" },
+        { rel: "source", href: "file:///etc/passwd" },
+        { rel: "source", href: "https://user:pass@example.org/secret" },
+        { rel: "source", href: "\u0000https://example.org/rejected" }
       ]
     });
 
@@ -50,7 +58,53 @@ describe("extractControlExportRow", () => {
       sourceLastModified: "2026-03-04"
     });
 
-    expect(row.links).toBe("https://example.org/a");
+    expect(row.links).toBe("https://example.org/a; http://example.org/plain");
+  });
+
+  it("haertet den Exportpfad Detail -> Row -> CSV gegen Formula-Injection", () => {
+    const detail = makeControlDetail({
+      id: "=APP.1",
+      title: "\u0000+Titel",
+      groupPathTitles: ["\u2007@Gruppe"],
+      class: "-klasse",
+      secLevel: "＝hoch",
+      effortLevel: "|niedrig",
+      statementText: "\u0001=SUM(A1:A2)",
+      guidanceText: "＝leitlinie",
+      propsMap: {
+        handlungsworte: ["\t+handeln"]
+      },
+      params: [
+        {
+          id: "=p1",
+          label: "Intervall",
+          values: ["30d"],
+          props: []
+        }
+      ],
+      tags: ["\u001B@tag"],
+      modalverbs: ["=MUSS"],
+      links: [
+        { rel: "source", href: "https://example.org/security" },
+        { rel: "source", href: "javascript:alert(1)" },
+        { rel: "source", href: "data:text/plain,abc" }
+      ]
+    });
+
+    const row = extractControlExportRow(detail, {
+      sourceVersion: "-1.0.0",
+      sourceLastModified: "@2026-03-10"
+    });
+
+    const formulaSensitiveColumns = CONTROL_EXPORT_COLUMNS.filter((column) => column.key !== "links");
+    for (const column of formulaSensitiveColumns) {
+      const csv = toCsv([{ value: row[column.key] }], [{ key: "value", header: column.header }], { withBom: false });
+      const dataLine = csv.split("\r\n")[1];
+      expect(dataLine).toBe(`'${row[column.key]}`);
+    }
+
+    const linksCsv = toCsv([{ value: row.links }], [{ key: "value", header: "links" }], { withBom: false });
+    expect(linksCsv).toBe("links\r\nhttps://example.org/security");
   });
 
   it("liefert leere Felder bei fehlenden Daten", () => {

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -54,6 +54,29 @@ describe("toCsv", () => {
     expect(lines[4]).toBe("'=SAFE");
   });
 
+  it("neutralisiert gefaehrliche Praefixe nach fuehrenden Control-Chars und Unicode-Whitespace", () => {
+    const values = [
+      "\u0000=1+1",
+      "\u001B+1+1",
+      "\u001F-1+1",
+      "\u007F@sum(A1:A2)",
+      "\u2007=1+1",
+      "\u00A0|cmd"
+    ];
+
+    const csv = toCsv(
+      values.map((value) => ({ value })),
+      [{ key: "value", header: "value" }],
+      { withBom: false }
+    );
+
+    const lines = csv.split("\r\n").slice(1);
+    expect(lines).toHaveLength(values.length);
+    for (let index = 0; index < values.length; index += 1) {
+      expect(lines[index]).toBe(`'${values[index]}`);
+    }
+  });
+
   it("neutralisiert Tab- und Carriage-Return-Praefixe", () => {
     const csv = toCsv(
       [{ value: "\t=1+1" }, { value: "\r=1+1" }],

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -10,7 +10,8 @@ export interface CsvOptions {
 }
 
 const DANGEROUS_FORMULA_PREFIXES = new Set(["=", "+", "-", "@", "|"]);
-const LEADING_IGNORED_CHARACTERS = /^[\uFEFF\s\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*/u;
+const LEADING_IGNORED_CHARACTERS =
+  /^[\u0000-\u001F\u007F\uFEFF\s\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*/u;
 
 function normalizeCell(value: unknown): string {
   if (value == null) {


### PR DESCRIPTION
## Summary
- extend CSV formula neutralization to account for leading control characters in addition to whitespace/unicode-space variants
- add matrix-style unit coverage for control-char + unicode-space prefixed formula payloads in src/lib/csv.test.ts
- add export-path guardrail test (detail to row to csv) and expanded link-scheme filtering checks in src/lib/controlExport.test.ts
- document the new regression guardrails in docs/security-review.md

## Validation
- npm run test:unit

Closes #50